### PR TITLE
Remove unneeded dropping of DHCP packets.

### DIFF
--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -294,26 +294,14 @@ def set_ep_specific_rules(suffix, iface, type, localips, mac):
     index += 1
 
     if type == IPV4:
-        # Allow outgoing DHCP packets.
+        # Allow outgoing v4 DHCP packets.
         rule = fiptables.Rule(type, "RETURN")
         rule.protocol = "udp"
         rule.create_udp_match("68", "67")
         fiptables.insert_rule(rule, from_chain, index)
         index += 1
-
-        #*********************************************************************#
-        #* Drop UDP that would allow this server to act as a DHCP server.    *#
-        #* This may be unnecessary - see                                     *#
-        #* https://github.com/Metaswitch/calico/issues/36                    *#
-        #*********************************************************************#
-        rule = fiptables.Rule(type, "DROP")
-        rule.protocol = "udp"
-        rule.create_udp_match("67", "68")
-        fiptables.insert_rule(rule, from_chain, index)
-        index += 1
-
     else:
-        # Allow outgoing DHCP packets.
+        # Allow outgoing v6 DHCP packets.
         rule = fiptables.Rule(type, "RETURN")
         rule.protocol = "udp"
         rule.create_udp_match("546", "547")

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -383,11 +383,6 @@ def add_endpoint_rules(suffix, tap, ipv4, ipv6, mac):
     rule.create_udp_match("68", "67")
     chain.rules.append(rule)
 
-    rule = stub_fiptables.Rule(IPV4, "DROP")
-    rule.protocol = "udp"
-    rule.create_udp_match("67", "68")
-    chain.rules.append(rule)
-
     if ipv4 is not None:
         rule = stub_fiptables.Rule(IPV4)
         rule.create_target("MARK", {"set_mark": "1"})


### PR DESCRIPTION
Endpoints are on an L3 routed network; this rule is not required.

Fixes final parts of issue #36 