### PR TITLE
Cl3 bird filter

### DIFF
--- a/etc/bird/calico-bird.conf.template
+++ b/etc/bird/calico-bird.conf.template
@@ -10,6 +10,17 @@ router id @MY_IP_ADDRESS@;
 
 
 filter tag_direct {
+# The ifname if match will match any route from a "calico advertisable interface"
+# and tag it with the advertise community string.  All other routes will also be 
+# accepted, but will be taged with the no advertise string
+# We start off unsetting all community strings on the route as a safety measure.
+# 
+# Update the ifname list if we have more interface types in Calico.  The dummy1
+# match is important.  There are "loopback" addresses we may want to advertise,
+# and those we don't.  Therefore, a loopback address that shouldn't be advertised
+# should be aliases on dummy0, and those that should be advertised are aliases
+# on dummy1.
+
 bgp_community.empty;
 if ( (ifname ~ "tap*") || (ifname ~ "veth*") || (ifname = "dummy1") ) then 
    {
@@ -18,8 +29,15 @@ if ( (ifname ~ "tap*") || (ifname ~ "veth*") || (ifname = "dummy1") ) then
    } else {
 	bgp_community.add ((@AS_NUMBER,@NO_ADVERT@));
 	accept;
+
    }
 filter export_bgp {
+# if a route is tagged with the export community string, then we will export it,
+# first stripping off the community strings (we don't want to leak internal Calico
+# community strings - they may conflict with other bits of infra - we can't assume the
+# operator has impecible BGP hygine.
+# All other routes are rejected (not exported).
+
 if (@AS_NUMBER@,@ADVERT@) ~ bgp_community then 
    { 
      bgp_community.empty;

--- a/etc/bird/calico-bird.conf.template
+++ b/etc/bird/calico-bird.conf.template
@@ -1,11 +1,32 @@
 
 router id @MY_IP_ADDRESS@;
 
-filter export_bgp {
-if ( net != 0.0.0.0/0 ) then {
-   accept;
+# Filters
+
+## tap*, veth*, dummy1 are networks we want to advertise
+## community strings:
+## @AS_NUMBER@:@NO_ADVERT@ - do not advertise via bgp
+## @AS_NUMBER@:@ADVERT@ - advertise it
+
+
+filter tag_direct {
+bgp_community.empty;
+if ( (ifname ~ "tap*") || (ifname ~ "veth*") || (ifname = "dummy1") ) then 
+   {
+	bgp_community.add ((@AS_NUMBER@,@ADVERT@));
+	accept;
+   } else {
+	bgp_community.add ((@AS_NUMBER,@NO_ADVERT@));
+	accept;
    }
-   reject;
+filter export_bgp {
+if (@AS_NUMBER@,@ADVERT@) ~ bgp_community then 
+   { 
+     bgp_community.empty;
+     accept;
+   } else {
+      reject;
+   }
 }
 
 # Configure synchronization between BIRD's routing tables and the
@@ -26,6 +47,7 @@ protocol device {
 
 protocol direct {
    debug all;
+   import filter tag_direct;
    interface "-dummy0", "dummy1", "eth*", "em*";
 }
 

--- a/etc/bird/calico-bird6.conf.template
+++ b/etc/bird/calico-bird6.conf.template
@@ -1,11 +1,32 @@
 
 router id @MY_IPV4_ADDRESS@;
 
-filter export_bgp {
-  if ( net != ::/0 ) then {
-     accept;
+# Filters
+
+## tap*, veth*, dummy1 are networks we want to advertise
+## community strings:
+## @AS_NUMBER@:@NO_ADVERT@ - do not advertise via bgp
+## @AS_NUMBER@:@ADVERT@ - advertise it
+
+
+filter tag_direct {
+bgp_community.empty;
+if ( (ifname ~ "tap*") || (ifname ~ "veth*") || (ifname = "dummy1") ) then 
+   {
+	bgp_community.add ((@AS_NUMBER@,@ADVERT@));
+	accept;
+   } else {
+	bgp_community.add ((@AS_NUMBER,@NO_ADVERT@));
+	accept;
    }
-   reject;
+filter export_bgp {
+if (@AS_NUMBER@,@ADVERT@) ~ bgp_community then 
+   { 
+     bgp_community.empty;
+     accept;
+   } else {
+      reject;
+   }
 }
 
 # Configure synchronization between BIRD's routing tables and the

--- a/etc/bird/calico-bird6.conf.template
+++ b/etc/bird/calico-bird6.conf.template
@@ -10,6 +10,17 @@ router id @MY_IPV4_ADDRESS@;
 
 
 filter tag_direct {
+# The ifname if match will match any route from a "calico advertisable interface"
+# and tag it with the advertise community string.  All other routes will also be 
+# accepted, but will be taged with the no advertise string
+# We start off unsetting all community strings on the route as a safety measure.
+# 
+# Update the ifname list if we have more interface types in Calico.  The dummy1
+# match is important.  There are "loopback" addresses we may want to advertise,
+# and those we don't.  Therefore, a loopback address that shouldn't be advertised
+# should be aliases on dummy0, and those that should be advertised are aliases
+# on dummy1.
+
 bgp_community.empty;
 if ( (ifname ~ "tap*") || (ifname ~ "veth*") || (ifname = "dummy1") ) then 
    {
@@ -20,6 +31,12 @@ if ( (ifname ~ "tap*") || (ifname ~ "veth*") || (ifname = "dummy1") ) then
 	accept;
    }
 filter export_bgp {
+# if a route is tagged with the export community string, then we will export it,
+# first stripping off the community strings (we don't want to leak internal Calico
+# community strings - they may conflict with other bits of infra - we can't assume the
+# operator has impecible BGP hygine.
+# All other routes are rejected (not exported).
+
 if (@AS_NUMBER@,@ADVERT@) ~ bgp_community then 
    { 
      bgp_community.empty;

--- a/etc/calico-gen-bird-conf.sh
+++ b/etc/calico-gen-bird-conf.sh
@@ -3,6 +3,12 @@
 BIRD_CONF=/etc/bird/bird.conf
 BIRD_CONF_TEMPLATE=/usr/share/calico/bird/calico-bird.conf.template
 
+# Community Strings Could be an argument if we want
+# However, we should make that optional, if we do
+
+$advert_community_string=777
+$no_advert_community_string=666
+
 # Require 3 arguments.
 [ $# -eq 3 ] || cat <<EOF
 
@@ -30,6 +36,8 @@ sed -e "
 s/@MY_IP_ADDRESS@/$my_ip_address/;
 s/@RR_IP_ADDRESS@/$rr_ip_address/;
 s/@AS_NUMBER@/$as_number/;
+s/@ADVERT@/$advert_community_string/;
+s/@NO_ADVERT@/$no_advert_community_string/;
 " < $BIRD_CONF_TEMPLATE > $BIRD_CONF
 
 echo BIRD configuration generated at $BIRD_CONF

--- a/etc/calico-gen-bird6-conf.sh
+++ b/etc/calico-gen-bird6-conf.sh
@@ -3,6 +3,13 @@
 BIRD_CONF=/etc/bird/bird6.conf
 BIRD_CONF_TEMPLATE=/usr/share/calico/bird/calico-bird6.conf.template
 
+# Community Strings Could be an argument if we want
+# However, we should make that optional, if we do
+
+$advert_community_string=777
+$no_advert_community_string=666
+
+
 # Require 4 arguments.
 [ $# -eq 4 ] || cat <<EOF
 
@@ -33,6 +40,8 @@ s/@MY_IPV4_ADDRESS@/$my_ipv4_address/;
 s/@MY_IPV6_ADDRESS@/$my_ipv6_address/;
 s/@RR_IPV6_ADDRESS@/$rr_ipv6_address/;
 s/@AS_NUMBER@/$as_number/;
+s/@ADVERT@/$advert_community_string/;
+s/@NO_ADVERT@/$no_advert_community_string/;
 " < $BIRD_CONF_TEMPLATE > $BIRD_CONF
 
 echo BIRD6 configuration generated at $BIRD_CONF


### PR DESCRIPTION
This set of changes does a few things:

1) Sets up two  community strings for "calico export via bgp" and "calico deny export via bgp" based on the AS_NUMBER that is set as part of the Bird configuration setup and two values set in the shell script that does the configuration (666 for deny, 777 for allow).  

2) Installs a filter on the import of direct routes that assigns one of the two community strings on each route imported.  The criteria is on the ifname where the route is learned.  Currently routes learned via tap*, veth*, and dummy1 are tagged with export, the rest tagged with !export.  

Dummy1 is a specific case.  lo* routes in Linux can't be used external to local machine.  dummy* interfaces can be.  There will be some routes that we want to be local machine only, and others that we may want to be reachable via the fabric, or wider (i.e. a dns resolver, API endpoint, etc).  Services that aren't in guests should therefore have their service address aliased to either dummy0 or dummy1 depending on if they want their service advertised beyond the local machine.

3) Installs a filter for BGP export that will ONLY export routes tagged with the "calico export via bgp" community string.

THESE CHANGES HAVE NOT BEEN TESTED - I don't have a testing infra here.  They look correct, and I've double checked them, but someone needs to test them before accepting the pull.

Christopher