### PR TITLE
Log out daemon name to syslog.

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -73,7 +73,7 @@ def default_logging():
     executable_name = os.path.basename(sys.argv[0])
     syslog_format = SYSLOG_FORMAT_STRING.format(excname=executable_name)
     syslog_formatter = logging.Formatter(syslog_format)
-    syslog_handler = logging.handlers.SysLogHandler()
+    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
     syslog_handler.setLevel(logging.ERROR)
     syslog_handler.setFormatter(syslog_formatter)
     root_logger.addHandler(syslog_handler)

--- a/calico/common.py
+++ b/calico/common.py
@@ -30,6 +30,12 @@ import errno
 AGENT_TYPE_CALICO = 'Calico agent'
 FORMAT_STRING = '%(asctime)s [%(levelname)s] %(name)s %(lineno)d: %(message)s'
 
+# This format string deliberately uses two different styles of format
+# specifier. The %()s form is used by the logging module: the {} form is used
+# by the code in this module. This allows us to dynamically generate the format
+# string used by the logger.
+SYSLOG_FORMAT_STRING = '{excname}: %(message)s'
+
 def mkdir_p(path):
     """http://stackoverflow.com/a/600612/190597 (tzot)"""
     try:
@@ -64,14 +70,18 @@ def default_logging():
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
 
+    executable_name = os.path.basename(sys.argv[0])
+    syslog_format = SYSLOG_FORMAT_STRING.format(excname=executable_name)
+    syslog_formatter = logging.Formatter(syslog_format)
     syslog_handler = logging.handlers.SysLogHandler()
     syslog_handler.setLevel(logging.ERROR)
+    syslog_handler.setFormatter(syslog_formatter)
     root_logger.addHandler(syslog_handler)
 
-    formatter = logging.Formatter(FORMAT_STRING)
+    file_formatter = logging.Formatter(FORMAT_STRING)
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setLevel(logging.DEBUG)
-    stream_handler.setFormatter(formatter)
+    stream_handler.setFormatter(file_formatter)
     root_logger.addHandler(stream_handler)
 
 


### PR DESCRIPTION
This ensures that we match the syslog format more closely. It resolves #71.

This needs functional testing to confirm it works.

The only problem with this fix is that I've hardcoded the binary executable names. That's fine for the 99% use-case, but doesn't necessarily scale well. It might be worth writing some code that can reliably determine the binary name from `sys.argv[0]`, but I didn't want to do that for this initial fix. Shout if anyone thinks I should.