### PR TITLE
Resolve issue #77 (allow Felix hostname to be explicitly set)

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -116,7 +116,11 @@ def default_logging():
     executable_name = os.path.basename(sys.argv[0])
     syslog_format = SYSLOG_FORMAT_STRING.format(excname=executable_name)
     syslog_formatter = logging.Formatter(syslog_format)
-    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    if os.path.exists("/dev/log"):
+        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    else:
+        # Probably unit tests running on windows.
+        syslog_handler = logging.handlers.SysLogHandler()
     syslog_handler.setLevel(logging.ERROR)
     syslog_handler.setFormatter(syslog_formatter)
     root_logger.addHandler(syslog_handler)

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -58,6 +58,11 @@ class Config(object):
             self.get_cfg_entry("global",
                                "ResyncIntervalSecs",
                                1800))
+
+        self.HOSTNAME        = self.get_cfg_entry("global",
+                                                  "FelixHostname",
+                                                  socket.gethostname())
+
         self.PLUGIN_ADDR     = self.get_cfg_entry("global",
                                                   "PluginAddress")
         self.ACL_ADDR        = self.get_cfg_entry("global",

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -74,7 +74,7 @@ class FelixAgent(object):
         self.zmq_context = context
 
         # The hostname of the machine on which this Felix is running.
-        self.hostname = socket.gethostname()
+        self.hostname = self.config.HOSTNAME
 
         # The sockets owned by this Felix, keyed off their socket type.
         self.sockets = {}

--- a/calico/felix/test/data/felix_debug.cfg
+++ b/calico/felix/test/data/felix_debug.cfg
@@ -3,6 +3,8 @@
 #EndpointRetryTimeMillis = 500
 # Time between complete resyncs
 #ResyncIntervalSecs = 1800
+# Hostname to use in messages - defaults to server hostname
+FelixHostname = test_hostname
 # Plugin and ACL manager addresses
 PluginAddress = 127.0.0.1
 ACLAddress    = 127.0.0.1

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -19,6 +19,7 @@ felix.test.test_config
 Top level tests for Felix configuration.
 """
 import logging
+import socket
 import sys
 import unittest
 from calico.felix.config import Config, ConfigException
@@ -33,6 +34,8 @@ class TestConfig(unittest.TestCase):
     def test_simple_good_config(self):
         config = Config("calico/felix/test/data/felix_basic.cfg")
         self.assertEqual(config.PLUGIN_ADDR, "localhost")
+        # We did not explicitly set HOSTNAME in this config - check defaulting.
+        self.assertEqual(config.HOSTNAME, socket.gethostname())
 
     def test_missing_section(self):
         with self.assertRaisesRegexp(ConfigException,

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -20,6 +20,7 @@ Top level tests for Felix.
 """
 import logging
 import mock
+import socket
 import sys
 import time
 import unittest
@@ -116,6 +117,8 @@ class TestBasic(unittest.TestCase):
         set_expected_global_rules()
         stub_fiptables.check_state(expected_iptables)
         stub_ipsets.check_state(expected_ipsets)
+
+        self.assertEqual(agent.hostname, "test_hostname")
 
     def test_no_work(self):
         """

--- a/etc/felix.cfg
+++ b/etc/felix.cfg
@@ -3,6 +3,8 @@
 #EndpointRetryTimeMillis = 500
 # Time between complete resyncs
 #ResyncIntervalSecs = 1800
+# Hostname to use in messages - defaults to server hostname
+#FelixHostname = hostname
 # Plugin and ACL manager addresses
 PluginAddress = controller
 ACLAddress    = controller


### PR DESCRIPTION
Includes a fix for a bug introduced with the fix to #75 (which broke Windows unit tests).

This is not complete in itself, though it is logically consistent.

* Calico-chef sample config files need updating.
* Something somewhere needs to actually set the value correctly in the install.