### PR TITLE
Remove workaround for (now fixed) python-iptables bug.

### DIFF
--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -119,7 +119,7 @@ def set_global_rules(config):
     # Add a rule that forces us through the chain we just created.
     chain = fiptables.get_chain(table, "PREROUTING")
     rule = fiptables.Rule(futils.IPV4, CHAIN_PREROUTING)
-    fiptables.insert_rule(rule, chain)
+    fiptables.insert_rule(rule, chain, force_position=False)
 
     #*************************************************************************#
     #* Now the filter table. This needs to have calico-filter-FORWARD and    *#
@@ -134,11 +134,11 @@ def set_global_rules(config):
         # Add rules that force us through the chain we just created.
         chain = fiptables.get_chain(table, "FORWARD")
         rule  = fiptables.Rule(type, CHAIN_FORWARD)
-        fiptables.insert_rule(rule, chain)
+        fiptables.insert_rule(rule, chain, force_position=False)
 
         chain = fiptables.get_chain(table, "INPUT")
         rule  = fiptables.Rule(type, CHAIN_INPUT)
-        fiptables.insert_rule(rule, chain)
+        fiptables.insert_rule(rule, chain, force_position=False)
 
 
 def set_ep_specific_rules(suffix, iface, type, localips, mac):
@@ -384,7 +384,10 @@ def set_ep_specific_rules(suffix, iface, type, localips, mac):
 
     rule = fiptables.Rule(type, from_chain_name)
     rule.in_interface = iface
-    fiptables.insert_rule(rule, chain, fiptables.RULE_POSN_LAST)
+    fiptables.insert_rule(rule,
+                          chain,
+                          fiptables.RULE_POSN_LAST,
+                          force_position=False)
 
     #*************************************************************************#
     #* Similarly, create the rules that direct packets that are forwarded    *#
@@ -395,11 +398,17 @@ def set_ep_specific_rules(suffix, iface, type, localips, mac):
 
     rule = fiptables.Rule(type, from_chain_name)
     rule.in_interface = iface
-    fiptables.insert_rule(rule, chain, fiptables.RULE_POSN_LAST)
+    fiptables.insert_rule(rule,
+                          chain,
+                          fiptables.RULE_POSN_LAST,
+                          force_position=False)
 
     rule = fiptables.Rule(type, to_chain_name)
     rule.out_interface = iface
-    fiptables.insert_rule(rule, chain, fiptables.RULE_POSN_LAST)
+    fiptables.insert_rule(rule,
+                          chain,
+                          fiptables.RULE_POSN_LAST,
+                          force_position=False)
 
 
 def del_rules(suffix, type):

--- a/debian/calico-felix.postinst
+++ b/debian/calico-felix.postinst
@@ -2,6 +2,6 @@
 
 set -e
 
-pip install python-iptables
+pip install "python-iptables>=0.7.0"
 
 #DEBHELPER#

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,2 +1,2 @@
 pyzmq
-python-iptables>=0.5.0
+python-iptables>=0.7.0

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -102,7 +102,7 @@ This package provides the Felix component.
 %post felix
 if [ $1 -eq 1 ] ; then
     # Initial installation
-    pip install python-iptables
+    pip install "python-iptables>=0.7.0"
     /sbin/chkconfig --add calico-felix
     /sbin/service calico-felix start >/dev/null 2>&1
 fi


### PR DESCRIPTION
Remove the workaround, but also require version 0.7.0 or better of python-iptables everywhere.