### PR TITLE
Do not hang in termination in zmq.

### DIFF
--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -24,8 +24,8 @@ The main logic for Felix.
 import argparse
 import collections
 import logging
+import os
 import socket
-import sys
 import time
 import uuid
 import zmq
@@ -727,8 +727,14 @@ def main():
             agent.run()
 
     except:
+        #*********************************************************************#
+        #* Log the exception then terminate. We cannot call sys.exit here    *#
+        #* because sometimes we hang on exit processing deep inside zmq      *#
+        #* (when the exception that causes termination was caused by a       *#
+        #* socket error).                                                    *#
+        #*********************************************************************#
         log.exception("Felix exiting after uncaught exception")
-        sys.exit(1)
+        os._exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
`sys.exit(1)` was hanging in some zmq library, according to gdb. We cannot afford to hang in termination, so us `os._exit` instead.

This might be controversial, but is at least pragmatic.