### PR TITLE
Replace fix to remove coverage of test code.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
 include = *felix*
-omit = *stub_* 
-       *test*
+omit = calico/felix/test/*
 branch = True

--- a/calico/felix/test/test_futils.py
+++ b/calico/felix/test/test_futils.py
@@ -69,7 +69,7 @@ class TestFutils(unittest.TestCase):
         retcode = futils.call_silent(args)
         self.assertEqual(retcode, 0)
 
-    def test_bad_check_call(self):
+    def test_bad_call_silent(self):
         # Test an invalid command - must parse but not return anything.
         args = ["ls", "wibble_wobble"]
         retcode = futils.call_silent(args)


### PR DESCRIPTION
Has drive-by fix of two methods with same name in test code.