### PR TITLE
Bring python version number up to date.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def collect_requirements():
 
 setuptools.setup(
     name = "calico",
-    version = "0.8",
+    version = "0.10",
     packages = setuptools.find_packages(),
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
This change brings the Python version number of the package up to date.

We need to update our release process to avoid this happening again: I'll open an issue to track it.