### PR TITLE
Prevent Felix programming interfaces that are down

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -112,3 +112,13 @@ def del_route(type, ip, tap):
         futils.check_call(["ip", "route", "del", ip, "dev", tap])
     else:
         futils.check_call(["ip", "-6", "route", "del", ip, "dev", tap])
+
+
+def interface_up(if_name):
+    """
+    Checks whether a given interface is up.
+    """
+    with open('/sys/class/net/%s/operstate' % if_name, 'r') as f:
+        state = f.read()
+
+    return 'up' in state

--- a/calico/felix/test/stub_devices.py
+++ b/calico/felix/test/stub_devices.py
@@ -68,3 +68,6 @@ def del_route(type, ip, tap_id):
         taps[tap_id].v4_ips.remove(ip)
     else:
         taps[tap_id].v6_ips.remove(ip)
+
+def interface_up(if_name):
+    return True


### PR DESCRIPTION
This change addresses #104.

Because of the urgency of this change (it's blocking FV runs) I have not currently added any unit tests, I've just made enough of a change to the test fabric to get all current tests to pass. This means it regresses coverage. I'll work on adding some tests this afternoon to cover this new code.

I also performed a substantial refactor of the route adding/deleting code. This is only half of what we needed to do here (there's still a chunk of repeated code) but we should be able to pull out the four repeated blocks into a shared function now. Should be no functional change there, but please confirm in code review. [This](https://docs.python.org/2/library/sets.html#set-objects) may help.