### PR TITLE
There are no more *.ini files to install.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,6 @@ export CALICODEPS = none
 override_dh_install:
 	install -d debian/tmp/usr/etc/calico
 	install etc/*.cfg debian/tmp/usr/etc/calico
-	install -d debian/tmp/usr/etc/neutron
-	install etc/*.ini debian/tmp/usr/etc/neutron
 	install -d debian/tmp/usr/share/calico/bird
 	install etc/bird/*.template debian/tmp/usr/share/calico/bird
 	install -d debian/tmp/usr/bin

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -172,8 +172,6 @@ install -p -m 644 %{SOURCE65} %{buildroot}%{_datadir}/calico/
 # Install config and other non-Python files
 install -d %{buildroot}%{_sysconfdir}/calico
 install etc/*.cfg %{buildroot}%{_sysconfdir}/calico
-install -d %{buildroot}%{_sysconfdir}/neutron
-install etc/*.ini %{buildroot}%{_sysconfdir}/neutron
 install -d %{buildroot}%{_datadir}/calico/bird
 install etc/bird/*.template %{buildroot}%{_datadir}/calico/bird
 install -d %{buildroot}%{_bindir}


### PR DESCRIPTION
This change follows on from #94, repairing our build process. We removed the only `.ini` file from the repository, so this stage of the build procedure fails. Let's simply remove it!