### PR TITLE
ACL Manager stops listening for network updates silently when a rule ref...

### DIFF
--- a/calico/acl_manager/processor.py
+++ b/calico/acl_manager/processor.py
@@ -29,9 +29,12 @@ class RuleProcessor(object):
         log.info("Recalculating ACLs")
         ns = self.network_store
 
-        # First get the group and endpoint information.
-        group_members = {group: ns.get_group_members(group) for
-                                                    (group) in ns.get_groups()}
+        # First get the group and endpoint information.  Use defaultdicts for
+        # both of these to support groups with no endpoints.
+        group_members = defaultdict(
+            dict,
+            {group: ns.get_group_members(group) for (group) in ns.get_groups()}
+        )
         endpoint_groups = defaultdict(list)
         for group, endpoints in group_members.iteritems():
             for endpoint_uuid in endpoints.keys():

--- a/calico/acl_manager/test/test_processor.py
+++ b/calico/acl_manager/test/test_processor.py
@@ -235,5 +235,25 @@ class TestProcessor(unittest.TestCase):
                           'outbound_default': 'deny'}}
         self.acl_store.test_assert_endpoint_acls('e1', 1, e1_acls)
 
+    def test_case4(self):
+        """
+        Test rule which refers to an unknown group.
+        """
+        # Rules can target another group, but that group may have no members.
+        self.network_store.test_set_groups(['g1'])
+        self.network_store.test_set_group_members('g1', {'e1': '10.1.1.1'})
+        self.network_store.test_set_group_rules('g1',
+                                                {'inbound': [{'group': 'g2',
+                                                              'cidr': None,
+                                                              'protocol': None,
+                                                              'port': None}],
+                                                 'outbound': [],
+                                                 'inbound_default': 'deny',
+                                                 'outbound_default': 'deny'})
+        self.processor.recalc_rules()
+        self.acl_store.test_assert_endpoints(['e1'])
+        self.acl_store.test_assert_endpoint_acls('e1', 1, self.empty_acls)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
...erences an empty security group

This fixes the bug and adds a unit test case for it.  The symptom is that ACL Manager stops processing any new information from the mechanism driver (it will still respond to Felix with the information it held at the time of failure).