### PR TITLE
Ensure ACL Manager exits cleanly with a log when worker threads crash

### DIFF
--- a/calico/acl_manager/test/stub_acl_publisher.py
+++ b/calico/acl_manager/test/stub_acl_publisher.py
@@ -28,9 +28,12 @@ class StubACLPublisher(object):
         self.acl_store = acl_store
         self.queue = Queue()
         self.expected_acls = {}
+        self.raise_exception = False
 
     def publish_endpoint_acls(self, endpoint_uuid, acls):
         self.queue.put((endpoint_uuid, acls))
+        if self.raise_exception:
+            raise Exception("Test exception")
 
     def test_query_endpoint_acls(self, endpoint_uuid):
         """
@@ -45,6 +48,9 @@ class StubACLPublisher(object):
     def test_set_expected_acls(self, endpoint_uuid, acls):
         assert endpoint_uuid not in self.expected_acls
         self.expected_acls[endpoint_uuid] = acls
+
+    def test_raise_exception(self):
+        self.raise_exception = True
 
     def test_wait_assert_all_acls_received(self):
         """

--- a/calico/acl_manager/utils.py
+++ b/calico/acl_manager/utils.py
@@ -13,16 +13,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import traceback
 import os
 import logging
 
 log = logging.getLogger(__name__)
 
-def terminate():  # pragma: nocover
+def terminate(exit_code=1):  # pragma: nocover
     """
     Log an Exception and terminate ACL Manager
+
+    This MUST only be called from inside an exception handler.
     """
-    log.critical("ACL Manager terminating - exception %s",
-                 traceback.format_exc())
-    os._exit(1)
+    log.exception("ACL Manager terminating")
+    os._exit(exit_code)

--- a/calico/acl_manager/utils.py
+++ b/calico/acl_manager/utils.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2014 Metaswitch Networks
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import traceback
+import os
+import logging
+
+log = logging.getLogger(__name__)
+
+def terminate():  # pragma: nocover
+    """
+    Log an Exception and terminate ACL Manager
+    """
+    log.critical("ACL Manager terminating - exception %s",
+                 traceback.format_exc())
+    os._exit(1)


### PR DESCRIPTION
This is still a work in progress - I've created the request just to chop the review up.

ACL Manager does most of its work in child threads, but (before this PR), if one of those crashes the rest of ACL Manager will often silently continue to operate, producing incorrect outputs.  This makes such issues particularly hard to debug.

This PR adds a try-except block around each worker thread which will log any exceptions and kill the whole process.  The service should then be restarted automatically.