### PR TITLE
Make Felix log its version ID.

### DIFF
--- a/calico/acl_manager/acl_manager.py
+++ b/calico/acl_manager/acl_manager.py
@@ -12,11 +12,11 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
-import zmq
-import logging
 import argparse
 import ConfigParser
+import logging
+import pkg_resources
+import zmq
 from calico.acl_manager.net_subscriber import NetworkSubscriber
 from calico.acl_manager.net_store import NetworkStore
 from calico.acl_manager.acl_publisher import ACLPublisher
@@ -70,6 +70,9 @@ def main():
                             file_level=file_level,
                             syslog_level=syslog_level,
                             stream_level=stream_level)
+
+    log.error("ACL Manager starting (version: %s)",
+              pkg_resources.get_distribution('calico'))
 
     # Create ZeroMQ context.
     context = zmq.Context()

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -23,6 +23,7 @@ The main logic for Felix.
 import argparse
 import logging
 import os
+import pkg_resources
 import socket
 import time
 import uuid
@@ -67,7 +68,8 @@ class FelixAgent(object):
         )
 
         # We have restarted and set up logs - tell the world.
-        log.error("Felix starting")
+        log.error("Felix starting (version: %s)",
+                  pkg_resources.get_distribution('calico'))
 
         # The ZeroMQ context for this Felix.
         self.zmq_context = context
@@ -171,7 +173,13 @@ class FelixAgent(object):
         self.resync_recd     = 0
         self.resync_expected = None
 
-        log.info("Do total resync - ID : %s" % self.resync_id)
+        #*********************************************************************#
+        #* Log the version here, ensuring that we log it periodically (in    *#
+        #* case we try to debug with logs that do not cover Felix starting). *#
+        #*********************************************************************#
+        log.info("Do total resync - ID : %s (version: %s)",
+                 self.resync_id,
+                 pkg_resources.get_distribution('calico'))
 
         # Mark all the endpoints as expecting to be resynchronized.
         for ep in self.endpoints.values():


### PR DESCRIPTION
Sample output lines : 

    2015-02-09 14:01:15,740 [ERROR] calico.felix.felix 72: Felix starting (calico 0.11)
    2015-02-09 14:01:15,744 [INFO] calico.felix.felix 182: Do total resync - ID : a5089f89-6b0b-4839-96e6-fb5d9c8a56e1 (calico 0.11)
