### PR TITLE
ACL Manager fix: Suppress superfluous unsolicited ACLUPDATE messages when nothing has changed

### DIFF
--- a/calico/acl_manager/test/stub_processor.py
+++ b/calico/acl_manager/test/stub_processor.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
+
 
 class StubRuleProcessor(object):
     """
@@ -69,4 +71,4 @@ class StubRuleProcessor(object):
         """
         Pass ACLs to the ACL Store.
         """
-        self.acl_store.update_endpoint_rules(endpoint_uuid, acls)
+        self.acl_store.update_endpoint_rules(endpoint_uuid, deepcopy(acls))

--- a/calico/acl_manager/test/test_acl_store.py
+++ b/calico/acl_manager/test/test_acl_store.py
@@ -116,6 +116,23 @@ class TestACLStore(unittest.TestCase):
         terminate_called.wait(3)
         self.acl_pub.test_wait_assert_all_acls_received()
 
+    def test_case4(self):
+        """
+        Check ACL Store suppresses superfluous no-op updates
+        """
+        # Add some ACLs - an update is published
+        self.processor.test_update_endpoint_acls('e1', self.acls)
+        self.acl_pub.test_set_expected_acls('e1', self.acls)
+        self.acl_pub.test_wait_assert_all_acls_received()
+
+        # Update the same ACLs without changing them
+        self.processor.test_update_endpoint_acls('e1', self.acls)
+        self.acl_pub.test_wait_assert_all_acls_received()
+
+        # Now query the ACLs to check they're still returned
+        self.acl_pub.test_query_endpoint_acls('e1')
+        self.acl_pub.test_set_expected_acls('e1', self.acls)
+        self.acl_pub.test_wait_assert_all_acls_received()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes issue #172.