### PR TITLE
Use ip route replace instead of add

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -94,12 +94,15 @@ def add_route(type, ip, tap, mac):
     """
     Add a route to a given tap interface (including arp config).
     Errors lead to exceptions that are not handled here.
+
+    Note that we use "ip route replace", since that overrides any imported
+    routes to the same IP, which might exist in the middle of a migration.
     """
     if type == futils.IPV4:
         futils.check_call(['arp', '-s', ip, mac, '-i', tap])
-        futils.check_call(["ip", "route", "add", ip, "dev", tap])
+        futils.check_call(["ip", "route", "replace", ip, "dev", tap])
     else:
-        futils.check_call(["ip", "-6", "route", "add", ip, "dev", tap])
+        futils.check_call(["ip", "-6", "route", "replace", ip, "dev", tap])
 
 
 def del_route(type, ip, tap):

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -60,13 +60,13 @@ class TestDevices(unittest.TestCase):
         with mock.patch('calico.felix.futils.check_call', return_value=retcode):
             devices.add_route(type, ip, tap, mac)
             futils.check_call.assert_any_call(['arp', '-s', ip, mac, '-i', tap])
-            futils.check_call.assert_called_with(["ip", "route", "add", ip, "dev", tap])
+            futils.check_call.assert_called_with(["ip", "route", "replace", ip, "dev", tap])
 
         type = futils.IPV6
         ip = "2001::"
         with mock.patch('calico.felix.futils.check_call', return_value=retcode):
             devices.add_route(type, ip, tap, mac)
-            futils.check_call.assert_called_with(["ip", "-6", "route", "add", ip, "dev", tap])
+            futils.check_call.assert_called_with(["ip", "-6", "route", "replace", ip, "dev", tap])
 
     def test_del_route(self):
         tap = "tap" + str(uuid.uuid4())[:11]


### PR DESCRIPTION
Fixes timing window when route exists during live migration