### PR TITLE
Fix delay seen on initial pings

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -89,6 +89,9 @@ def configure_tap(tap):
     with open("/proc/sys/net/ipv4/conf/%s/proxy_arp" % tap, 'wb') as f:
         f.write('1')
 
+    with open("/proc/sys/net/ipv4/neigh/%s/proxy_delay" % tap, 'wb') as f:
+        f.write('0')
+
 
 def add_route(type, ip, tap, mac):
     """


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/calico/issues/164.  Initial ping was delayed by the default value of the proxy_delay setting, which caused the ARP response from the host to be delayed.  Since the ARPs are point-to-point in our implementation, I can't see any reason that delay would be helpful.  (The manpage says the default value of "80 jiffys" prevents a flood in certain circumstances.)

Retested using calico-docker revision ad6ec3bdb23d08faf15050b3e3467a494208c8db with felix container replaced by the code from this branch.  Seeing initial pings in range of 1-2ms.