### PR TITLE
Remove build and install dependencies on python-iptables

### DIFF
--- a/debian/calico-felix.postinst
+++ b/debian/calico-felix.postinst
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e
-
-pip install "python-iptables>=0.7.0"
-
-#DEBHELPER#

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,2 +1,1 @@
 pyzmq
-python-iptables>=0.7.0

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -96,7 +96,6 @@ This package provides the Felix component.
 %post felix
 if [ $1 -eq 1 ] ; then
     # Initial installation
-    pip install "python-iptables>=0.7.0"
     /sbin/chkconfig --add calico-felix
     /sbin/service calico-felix start >/dev/null 2>&1
 fi


### PR DESCRIPTION
Following Peter's removal of the code, this removes the requirements and build steps.