### PR TITLE
[DO NOT MERGE] Increase set size to 6553500 elements

### DIFF
--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -46,7 +46,16 @@ def create(name, typename, family):
     if futils.call_silent(["ipset", "list", name]) != 0:
         # ipset list failed - either does not exist, or an error. Either way,
         # try creation, throwing an error if it does not work.
-        futils.check_call(["ipset", "create", name, typename, "family", family])
+        futils.check_call(
+            ["ipset",
+             "create",
+             name,
+             typename,
+             "family",
+             family,
+             "maxelem",
+             "6553500"]
+        )
 
 def destroy(name):
     """

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+calico (0.12.2~rc1) trusty; urgency=medium
+
+  * Temporary workaround for ipset maximum size.
+
+ -- Cory Benfield <cory.benfield@metaswitch.com>  Thu, 19 Feb 2015 14:10:10 +0000
+
 calico (0.12.1) trusty; urgency=medium
 
   * Bug fixes and improvements to Calico components

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-calico (0.12.2~rc1) trusty; urgency=medium
+calico (0.12.2~rc3) trusty; urgency=medium
 
   * Temporary workaround for ipset maximum size.
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def collect_requirements():
 
 setuptools.setup(
     name = "calico",
-    version = "0.12.1",
+    version = "0.12.2~rc1",
     packages = setuptools.find_packages(),
     entry_points = {
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def collect_requirements():
 
 setuptools.setup(
     name = "calico",
-    version = "0.12.2~rc1",
+    version = "0.12.2~rc3",
     packages = setuptools.find_packages(),
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
This represents one very stupid 'fix' to #206 and ameliorates #205. We **absolutely should not merge this**, because it increases the resting size of an ipset, and doesn't deal with most of the core problems. This PR is open only to provide a clue to a temporary patch for anyone who encounters these problems.