### PR TITLE
Remove python 2.7 only features so we work on python 2.6 again.

### DIFF
--- a/calico/acl_manager/processor.py
+++ b/calico/acl_manager/processor.py
@@ -33,7 +33,7 @@ class RuleProcessor(object):
         # both of these to support groups with no endpoints.
         group_members = defaultdict(
             dict,
-            {group: ns.get_group_members(group) for (group) in ns.get_groups()}
+            ((group, ns.get_group_members(group)) for group in ns.get_groups())
         )
         endpoint_groups = defaultdict(list)
         for group, endpoints in group_members.iteritems():

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -247,7 +247,7 @@ class FelixAgent(object):
         #* Now remove rules for any endpoints that should no longer          *#
         #* exist. This method returns a set of endpoint suffices.            *#
         #*********************************************************************#
-        known_suffices = {ep.suffix for ep in self.endpoints.values()}
+        known_suffices = set(ep.suffix for ep in self.endpoints.values())
 
         for type in [futils.IPV4, futils.IPV6]:
             found_suffices  = frules.list_eps_with_rules(self.iptables_state,

--- a/calico/felix/fiptables.py
+++ b/calico/felix/fiptables.py
@@ -267,7 +267,7 @@ class Rule(object):
 
     FLAG_TO_FIELD = dict(tuples)
     KNOWN_FIELDS = [ a[1] for a in tuples ]
-    FIELD_TO_FLAG = {field: flag for flag, field in tuples}
+    FIELD_TO_FLAG = dict((field, flag) for flag, field in tuples)
 
     def __init__(self, type, target=None):
         self.type = type

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -729,9 +729,9 @@ def list_eps_with_rules(iptables_state, type):
     #*************************************************************************#
     table = iptables_state.get_table(type, "filter")
 
-    eps  = {chain.name.replace(CHAIN_TO_PREFIX, "")
-            for chain in table.chains.values()
-            if chain.name.startswith(CHAIN_TO_PREFIX)}
+    eps  = set(chain.name.replace(CHAIN_TO_PREFIX, "")
+               for chain in table.chains.values()
+               if chain.name.startswith(CHAIN_TO_PREFIX))
 
     names = ipsets.list_names()
     for name in names:

--- a/calico/openstack/test/test_plugin.py
+++ b/calico/openstack/test/test_plugin.py
@@ -196,7 +196,7 @@ class TestPlugin(unittest.TestCase):
             #*****************************************************************#
             #* Add this to the test code's list of known sockets.            *#
             #*****************************************************************#
-            self.sockets |= {socket}
+            self.sockets.add(socket)
 
             return socket
 
@@ -394,7 +394,7 @@ class TestPlugin(unittest.TestCase):
                     print "T=%s: %s: Wake up!" % (current_time, queue.stack)
                     del sleepers[queue]
                     queue.put_nowait('Wake up!')
-                    
+
             #*****************************************************************#
             #* Allow woken (and possibly other) threads to run.              *#
             #*****************************************************************#
@@ -437,14 +437,14 @@ class TestPlugin(unittest.TestCase):
                                                      (addr, port))}
         self.assertEqual(len(bound_sockets), 1)
         return bound_sockets.pop()
-        
+
     def test_bind_host(self):
         #*********************************************************************#
         #* Test binding to a specific IP address.                            *#
         #*********************************************************************#
         ip_addr = '192.168.1.1'
         m_oslo.config.cfg.CONF.bind_host = ip_addr
-        
+
         #*********************************************************************#
         #* Tell the driver to initialize.                                    *#
         #*********************************************************************#
@@ -462,7 +462,7 @@ class TestPlugin(unittest.TestCase):
         #* Don't provide bind_host config.                                   *#
         #*********************************************************************#
         m_oslo.config.cfg.CONF.bind_host = None
-        
+
         #*********************************************************************#
         #* Tell the driver to initialize.                                    *#
         #*********************************************************************#
@@ -745,7 +745,7 @@ class TestPlugin(unittest.TestCase):
     #* operations. These all represent different manifestations of           *#
     #* networking connectivity trouble.                                      *#
     #*************************************************************************#
- 
+
     def test_felix_router_addr_in_use(self):
 
         #*********************************************************************#


### PR DESCRIPTION
Red Hat / CentOS 6.5 only come with python 2.6, so we need to rip out all python 2.7 features to support them.