### PR TITLE
Use default metadata port 8775.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -72,7 +72,7 @@ class Config(object):
                                                   "127.0.0.1")
         self.METADATA_PORT   = self.get_cfg_entry("global",
                                                   "MetadataPort",
-                                                  "9697")
+                                                  "8775")
         self.LOCAL_ADDR      = self.get_cfg_entry("global",
                                                   "LocalAddress",
                                                   "*")

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -125,7 +125,7 @@ def set_global_rules(config, iface_prefix, iptables_state):
     else:
         # Now set the chain to have a single rule by adding it at the start,
         # then truncating. The rule looks like this.
-        #  DNAT tcp -- any any anywhere 169.254.169.254 tcp dpt:http to:127.0.0.1:9697
+        #  DNAT tcp -- any any anywhere 169.254.169.254 tcp dpt:http to:127.0.0.1:8775
         rule          = fiptables.Rule(futils.IPV4)
         rule.dst      = "169.254.169.254/32"
         rule.protocol = "tcp"

--- a/calico/felix/test/data/felix.cfg
+++ b/calico/felix/test/data/felix.cfg
@@ -8,7 +8,7 @@ PluginAddress = 127.0.0.1
 ACLAddress    = 127.0.0.1
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_bad_dns.cfg
+++ b/calico/felix/test/data/felix_bad_dns.cfg
@@ -8,7 +8,7 @@ PluginAddress = 127.0.0.1
 ACLAddress    = 127.0.0.1
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 MetadataAddr  = ThisSurelyCannotResolve
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_bad_localaddr.cfg
+++ b/calico/felix/test/data/felix_bad_localaddr.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 LocalAddress = IDoNotResolve
 
 [log]

--- a/calico/felix/test/data/felix_basic.cfg
+++ b/calico/felix/test/data/felix_basic.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_blank_plugin.cfg
+++ b/calico/felix/test/data/felix_blank_plugin.cfg
@@ -4,11 +4,11 @@
 # Time between complete resyncs
 #ResyncIntervalSecs = 1800
 # Plugin and ACL manager addresses
-PluginAddress = 
+PluginAddress =
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_debug.cfg
+++ b/calico/felix/test/data/felix_debug.cfg
@@ -10,7 +10,7 @@ PluginAddress = 127.0.0.1
 ACLAddress    = 127.0.0.1
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_extra.cfg
+++ b/calico/felix/test/data/felix_extra.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 # This field is meaningless and will be ignored.
 ThisIsNonsense = 1234
 

--- a/calico/felix/test/data/felix_invalid_acl.cfg
+++ b/calico/felix/test/data/felix_invalid_acl.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = ThisMustNotResolve
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_localaddr_all.cfg
+++ b/calico/felix/test/data/felix_localaddr_all.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 LocalAddress = *
 
 [log]

--- a/calico/felix/test/data/felix_localaddr_host.cfg
+++ b/calico/felix/test/data/felix_localaddr_host.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 LocalAddress = localhost
 
 [log]

--- a/calico/felix/test/data/felix_localaddr_specific.cfg
+++ b/calico/felix/test/data/felix_localaddr_specific.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 LocalAddress = 1.2.3.4
 
 [log]

--- a/calico/felix/test/data/felix_missing_section.cfg
+++ b/calico/felix/test/data/felix_missing_section.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [connection]
 # Time with no data on a connection after which we give up on the

--- a/calico/felix/test/data/felix_no_metadata.cfg
+++ b/calico/felix/test/data/felix_no_metadata.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 MetadataAddr  = None
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/data/felix_nologfile.cfg
+++ b/calico/felix/test/data/felix_nologfile.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log severities for the Felix log and for syslog.

--- a/calico/felix/test/data/felix_nologfile2.cfg
+++ b/calico/felix/test/data/felix_nologfile2.cfg
@@ -8,7 +8,7 @@ PluginAddress = localhost
 ACLAddress    = localhost
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 
 [log]
 # Log file path.

--- a/calico/felix/test/stub_fiptables.py
+++ b/calico/felix/test/stub_fiptables.py
@@ -200,7 +200,7 @@ class TableState(fiptables.TableState):
         rule.dst = "169.254.169.254/32"
         rule.protocol = "tcp"
         rule.create_tcp_match("80")
-        rule.create_target("DNAT", {'to-destination': '127.0.0.1:9697'})
+        rule.create_target("DNAT", {'to-destination': '127.0.0.1:8775'})
         chain.rules.append(rule)
 
         table = self.get_table(IPV6, "filter")

--- a/etc/felix.cfg.example
+++ b/etc/felix.cfg.example
@@ -8,7 +8,8 @@
 # Plugin and ACL manager addresses
 PluginAddress = controller
 ACLAddress    = controller
-# Metadata IP (or host) and port. If no metadata configuration, set to None
+# Metadata IP (or host) and port. If metadata is not desired, set both
+# MetadataAddr and MetadataPort to 'None'.
 #MetadataAddr  = 127.0.0.1
 #MetadataPort  = 8775
 # Address to bind to - either "*" or an IPv4 address (or hostname)

--- a/etc/felix.cfg.example
+++ b/etc/felix.cfg.example
@@ -10,7 +10,7 @@ PluginAddress = controller
 ACLAddress    = controller
 # Metadata IP (or host) and port. If no metadata configuration, set to None
 #MetadataAddr  = 127.0.0.1
-#MetadataPort  = 9697
+#MetadataPort  = 8775
 # Address to bind to - either "*" or an IPv4 address (or hostname)
 #LocalAddress = *
 


### PR DESCRIPTION
This switches the default metadata port from 9697 (which is for neutron's metadata proxy) to 8775 (which is for nova-api, the service that actually provides metadata in Calico).