### PR TITLE
Felix programs proxy NDP

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -75,7 +75,8 @@ def list_interface_ips(type, interface):
 
 def configure_interface(interface):
     """
-    Configure the various proc file system parameters for the interface.
+    Configure the various proc file system parameters for the interface to
+    work for IPv4 traffic.
 
     Specifically, allow packets from controlled interfaces to be directed to
     localhost, and enable proxy ARP.
@@ -88,6 +89,25 @@ def configure_interface(interface):
 
     with open("/proc/sys/net/ipv4/neigh/%s/proxy_delay" % interface, 'wb') as f:
         f.write('0')
+
+
+def configure_interface_ipv6(if_name, proxy_targets):
+    """
+    Configure an interface to support IPv6 traffic from an endpoint.
+      - Enable proxy NDP on the interface.
+      - Program the given proxy targets (gateway(s) the endpoint will use).
+
+    :param if_name: The name of the interface to configure.
+    :param proxy_targets: IPv6 addresses which are proxied on this interface
+    for NDP.
+    :return: None
+    """
+    with open("/proc/sys/net/ipv6/conf/%s/proxy_ndp" % if_name, 'wb') as f:
+        f.write('1')
+
+    for target in proxy_targets:
+        futils.check_call(["ip", "-6", "neigh", "add",
+                           "proxy", str(target), "dev", if_name])
 
 
 def add_route(type, ip, interface, mac):

--- a/calico/felix/exceptions.py
+++ b/calico/felix/exceptions.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 Metaswitch Networks
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""
+felix.exceptions
+~~~~~~~~~~~
+
+Shared exceptions used in Felix.
+"""
+
+class InvalidRequest(Exception):
+    """
+    Exception that allows us to report an invalid request.
+    """
+    def __init__(self, message, fields):
+        super(InvalidRequest, self).__init__(message)
+        self.fields = fields
+
+    def __str__(self):
+        return "%s (request : %s)" % (self.message, self.fields)

--- a/calico/felix/exceptions.py
+++ b/calico/felix/exceptions.py
@@ -31,3 +31,15 @@ class InvalidRequest(Exception):
 
     def __str__(self):
         return "%s (request : %s)" % (self.message, self.fields)
+
+
+class InconsistentIPVersion(Exception):
+    """
+    Tried to create an Address with inconsistent IP versions between
+    properties, e.g. IP and gateway.
+    """
+    pass
+
+
+class InvalidAddress(Exception):
+    pass

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -30,8 +30,9 @@ import uuid
 import zmq
 
 from calico.felix.config import Config
-from calico.felix.endpoint import Address, Endpoint, InvalidAddress
+from calico.felix.endpoint import Endpoint
 from calico.felix.fsocket import Socket, Message
+from calico.felix.exceptions import InvalidRequest
 from calico.felix import fiptables
 from calico.felix import frules
 from calico.felix import fsocket
@@ -636,42 +637,11 @@ class FelixAgent(object):
         """
         Updates an endpoint's data.
         """
-        try:
-            mac = fields['mac']
-        except KeyError:
-            raise InvalidRequest("Missing \"mac\" field", fields)
+        endpoint.store_update(fields)
 
-        try:
-            state = fields['state']
-        except KeyError:
-            raise InvalidRequest("Missing \"state\" field", fields)
-
-        try:
-            addrs = fields['addrs']
-        except KeyError:
-            raise InvalidRequest("Missing \"addrs\" field", fields)
-
-        addresses = set()
-        try:
-            for addr in addrs:
-                addresses.add(Address(addr))
-        except InvalidAddress:
-            log.error("Invalid address for endpoint %s : %s",
-                      endpoint.uuid, fields)
-            raise InvalidRequest("Invalid address for endpoint",
-                                 fields)
-
-        if state not in Endpoint.STATES:
-            log.error("Invalid state %s for endpoint %s : %s",
-                      state, endpoint.uuid, fields)
-            raise InvalidRequest("Invalid state \"%s\"" % state, fields)
-
-        endpoint.addresses = addresses
-
-        endpoint.mac = mac.encode('ascii')
-        endpoint.state = state.encode('ascii')
-
-        # Program the endpoint - i.e. set things up for it.
+        # store_update throws InvalidRequest exception if unsuccessful, so if
+        # we get here it is safe to program the endpoint - i.e. set things up
+        # for it.
         log.debug("Program %s", endpoint.suffix)
         if endpoint.program_endpoint(self.iptables_state):
             # Failed to program this endpoint - put on the retry list.
@@ -840,14 +810,3 @@ def main():
 if __name__ == "__main__":
     main()
 
-
-class InvalidRequest(Exception):
-    """
-    Exception that allows us to report an invalid request.
-    """
-    def __init__(self, message, fields):
-        super(InvalidRequest, self).__init__(message)
-        self.fields = fields
-
-    def __str__(self):
-        return "%s (request : %s)" % (self.message, self.fields)

--- a/calico/felix/test/stub_devices.py
+++ b/calico/felix/test/stub_devices.py
@@ -54,7 +54,12 @@ def list_interface_ips(type, iface_id):
     else:
         return ifaces[iface_id].v6_ips.copy()
 
+
 def configure_interface(iface_id):
+    pass
+
+
+def configure_interface_ipv6(if_name, proxy_targets):
     pass
 
 def add_route(type, ip, iface_id, mac):

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -27,6 +27,7 @@ import uuid
 import calico.felix.devices as devices
 import calico.felix.futils as futils
 import calico.felix.test.stub_utils as stub_utils
+from netaddr import IPAddress
 
 # Logger
 log = logging.getLogger(__name__)
@@ -141,6 +142,35 @@ class TestDevices(unittest.TestCase):
                  mock.call('/proc/sys/net/ipv4/neigh/%s/proxy_delay' %tap, 'wb'),
                  M_ENTER, mock.call().write('0'), M_CLEAN_EXIT,]
         m_open.assert_has_calls(calls)
+
+    def test_configure_interface_ipv6_mainline(self):
+        """
+        Test that configure_interface_ipv6_mainline
+            - opens and writes to the /proc system to enable proxy NDP on the
+              interface.
+            - calls ip -6 neigh to set up the proxy targets.
+
+        Mainline test has two proxy targets.
+        """
+        m_open = mock.mock_open()
+        rc = futils.CommandOutput("", "")
+        if_name = "tap3e5a2b34222"
+        proxy_targets = [IPAddress("2001::3:4"),
+                         IPAddress("2001:3::4")]
+        with mock.patch('__builtin__.open', m_open, create=True), \
+             mock.patch('calico.felix.futils.check_call', return_value=rc) as m_check_call:
+            devices.configure_interface_ipv6(if_name, proxy_targets)
+            calls = [mock.call('/proc/sys/net/ipv6/conf/%s/proxy_ndp' % if_name,
+                               'wb'),
+                     M_ENTER,
+                     mock.call().write('1'),
+                     M_CLEAN_EXIT]
+            m_open.assert_has_calls(calls)
+            ip_calls = []
+            for target in proxy_targets:
+                ip_calls.append(mock.call(["ip", "-6", "neigh", "add", "proxy",
+                                           str(target), "dev", if_name]))
+            m_check_call.assert_has_calls(ip_calls)
 
     def test_interface_up1(self):
         """

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -23,11 +23,13 @@ import sys
 import unittest
 import uuid
 from contextlib import nested
+from netaddr import IPAddress
 
 import calico.felix.devices as devices
 import calico.felix.endpoint as endpoint
 import calico.felix.frules as frules
 import calico.felix.futils as futils
+from calico.felix.exceptions import InvalidRequest
 
 from collections import namedtuple
 Config = namedtuple('Config', ['IFACE_PREFIX', 'SUFFIX_LEN'])
@@ -152,3 +154,193 @@ class TestEndpoint(unittest.TestCase):
         self.assertEqual(mock_list.call_count, 1)
         self.assertEqual(mock_del_route.call_count, 1)
         self.assertEqual(mock_del_rules.call_count, 0)
+
+    def test_store_update_valid(self):
+        """
+        Test that store update works for valid data.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        fields = {u'mac': u'11:22:33:44:55:66',
+                  u'state': u'enabled',
+                  u'addrs': [{u"addr": u"10.0.65.2",
+                              u"gateway": u"10.0.65.1",
+                              u"properties": {u"gr": False}
+                             }]
+                  }
+        ep.store_update(fields)
+        self.assertEqual(ep.state, "enabled")
+        self.assertEqual(ep.mac, "11:22:33:44:55:66")
+        self.assertEqual(len(ep.addresses), 1)
+        (ip, addr) = ep.addresses.popitem()
+        self.assertEqual(ip, addr.ip)
+        self.assertEqual(addr.ip, IPAddress("10.0.65.2"))
+        self.assertEqual(addr.gateway, IPAddress("10.0.65.1"))
+
+        # Now, modify one of the addresses and update again.
+        fields[u'addrs'][0][u'addr'] = u'10.34.66.1'
+        ep.store_update(fields)
+        self.assertEqual(ep.state, "enabled")
+        self.assertEqual(ep.mac, "11:22:33:44:55:66")
+        self.assertEqual(len(ep.addresses), 1)
+        (ip, addr) = ep.addresses.popitem()
+        self.assertEqual(ip, addr.ip)
+        self.assertEqual(addr.ip, IPAddress("10.34.66.1"))
+        self.assertEqual(addr.gateway, IPAddress("10.0.65.1"))
+
+    def test_store_update_no_addrs(self):
+        """
+        Test that store update works even if there are no addresses.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        fields = {u'mac': u'11:22:33:44:55:66',
+                  u'state': u'enabled',
+                  u'addrs': []
+                  }
+        ep.store_update(fields)
+        self.assertEqual(ep.state, "enabled")
+        self.assertEqual(ep.mac, "11:22:33:44:55:66")
+        self.assertEqual(len(ep.addresses), 0)
+
+    def test_store_update_2_addrs(self):
+        """
+        Test that store update works for multiple IP addresses.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        # Mix ascii and unicode to make sure we cope.
+        fields = {u'mac': '11:22:33:44:55:66',
+                  'state': u'enabled',
+                  u'addrs': [{u'addr': '10.0.65.2',
+                              "gateway": u"10.0.65.1",
+                              u"properties": {u"gr": False}
+                             },
+                             {"addr": u"2001::3:4",
+                              u"gateway": "2001::1",
+                              "properties": {"gr": False}
+                             },]
+                  }
+        ep.store_update(fields)
+        self.assertEqual(ep.state, "enabled")
+        self.assertEqual(ep.mac, "11:22:33:44:55:66")
+        self.assertEqual(len(ep.addresses), 2)
+
+        # Set comprehension to get the 2 IP addresses
+        ips = {address.ip for address in ep.addresses.values()}
+        self.assertSetEqual(ips, {IPAddress("10.0.65.2"),
+                                  IPAddress("2001::3:4")})
+
+        # Set comprehension to get the gateways
+        gws = {address.gateway for address in ep.addresses.values()}
+        self.assertSetEqual(gws, {IPAddress("10.0.65.1"),
+                                  IPAddress("2001::1")})
+
+    def test_store_update_2_addrs_repeated(self):
+        """
+        Test that store update throws an exception if an address is repeated.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        # Mix ascii and unicode to make sure we cope.
+        fields = {u'mac': '11:22:33:44:55:66',
+                  'state': u'enabled',
+                  u'addrs': [{u'addr': '10.0.65.2',
+                              "gateway": u"10.0.65.1",
+                              u"properties": {u"gr": False}
+                             },
+                             {u'addr': '10.0.65.2',
+                              "gateway": u"10.0.65.10",
+                              u"properties": {u"gr": True}
+                             },]
+                  }
+        self.assertRaises(InvalidRequest, ep.store_update, fields)
+
+    def test_store_update_ip_gw_mismatch(self):
+        """
+        Test that store update throws an exception if a IP and gateway are
+        different versions.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        # Mix ascii and unicode to make sure we cope.
+        fields = {u'mac': '11:22:33:44:55:66',
+                  'state': u'enabled',
+                  u'addrs': [{u'addr': '10.0.65.2',
+                              "gateway": u"2001::10:0:65:4",
+                              u"properties": {u"gr": False}
+                             },]
+                  }
+        self.assertRaises(InvalidRequest, ep.store_update, fields)
+
+    def test_store_update_no_ip(self):
+        """
+        Test that store update throws an exception if a IP and gateway are
+        different versions.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        # Mix ascii and unicode to make sure we cope.
+        fields = {u'mac': '11:22:33:44:55:66',
+                  'state': u'enabled',
+                  u'addrs': [{"gateway": u"2001::10:0:65:4",
+                              u"properties": {u"gr": False}
+                             },]
+                  }
+        self.assertRaises(InvalidRequest, ep.store_update, fields)
+
+    def test_store_update_no_gw(self):
+        """
+        Test that store update works for valid data.
+        """
+        ep_id = str(uuid.uuid4())
+        prefix = "vth"
+        interface = prefix + ep_id[:11]
+        ep = endpoint.Endpoint(ep_id,
+                               'aa:bb:cc:dd:ee:ff',
+                               interface,
+                               prefix)
+        fields = {u'mac': u'11:22:33:44:55:66',
+                  u'state': u'enabled',
+                  u'addrs': [{u"addr": u"10.0.65.2",
+                              u"properties": {u"gr": False}
+                             }]
+                  }
+        ep.store_update(fields)
+        self.assertEqual(ep.state, "enabled")
+        self.assertEqual(ep.mac, "11:22:33:44:55:66")
+        self.assertEqual(len(ep.addresses), 1)
+        (ip, addr) = ep.addresses.popitem()
+        self.assertEqual(ip, addr.ip)
+        self.assertEqual(addr.ip, IPAddress("10.0.65.2"))
+        self.assertEqual(addr.gateway, None)


### PR DESCRIPTION
Felix enables proxy NDP on endpoint interfaces and programs the addresses of the gateways configured.

- Modifies endpoint.Address to track the gateway for each `addr` passed on the API.
- Address is now backed by netaddr.IPAddress, rather than strings for the IP and gateway.
- Refactor code in felix.py that updates Endpoint objects to be a method on the Endpoint.
- Improved UT of endpoint updates.