### PR TITLE
If tox fails, so should run-unit-test.sh

### DIFF
--- a/run-unit-test.sh
+++ b/run-unit-test.sh
@@ -5,6 +5,7 @@
 # Invoke as './run-unit-test.sh'. Arguments to this script are passed directly
 # to tox: e.g., to force a rebuild of tox's virtual environments, invoke this
 # script as './run-unit-test.sh -r'.
+set -e
 
 coverage erase
 tox "$@"


### PR DESCRIPTION
Jenkins runs revealed that if tox reports a failure the run could still succeed, so long as coverage html successfully ran. This updates the script to fail if tox fails.