### PR TITLE
Handle flaky ACL tests by overriding assertDictEqual.

### DIFF
--- a/calico/acl_manager/test/test_processor.py
+++ b/calico/acl_manager/test/test_processor.py
@@ -60,6 +60,7 @@ class TestProcessor(unittest.TestCase):
         be ordered for dict comparison. It's an unfortunate hack, but c'est la
         vie.
         """
+        self.assertEqual(len(d1), len(d2))
         for k,v1 in d1.iteritems():
             self.assertIn(k, d2, msg)
             v2 = d2[k]
@@ -68,7 +69,6 @@ class TestProcessor(unittest.TestCase):
                 self.assertItemsEqual(v1, v2, msg)
             else:
                 self.assertEqual(v1, v2, msg)
-        return True
 
     def test_case1(self):
         """

--- a/calico/acl_manager/test/test_processor.py
+++ b/calico/acl_manager/test/test_processor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import sys
 from copy import deepcopy
 
@@ -52,6 +53,22 @@ class TestProcessor(unittest.TestCase):
                          'inbound_default': 'deny',
                          'outbound': [],
                          'outbound_default': 'deny'}}
+
+    def assertDictEqual(self, d1, d2, msg=None):
+        """
+        This override for assertDictEqual ensures that lists do not need to
+        be ordered for dict comparison. It's an unfortunate hack, but c'est la
+        vie.
+        """
+        for k,v1 in d1.iteritems():
+            self.assertIn(k, d2, msg)
+            v2 = d2[k]
+            if (isinstance(v1, collections.Iterable) and
+                not isinstance(v1, basestring)):
+                self.assertItemsEqual(v1, v2, msg)
+            else:
+                self.assertEqual(v1, v2, msg)
+        return True
 
     def test_case1(self):
         """


### PR DESCRIPTION
This deals with the intermittent ACL manager unit test case failure that I've seen over the last few days by forcing unordered comparison of lists nested inside more complex dictionary structures.