### PR TITLE
Fix unit tests on Python 2.6

### DIFF
--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -27,6 +27,7 @@ import uuid
 import calico.felix.devices as devices
 import calico.felix.futils as futils
 import calico.felix.test.stub_utils as stub_utils
+from contextlib import nested
 from netaddr import IPAddress
 
 if sys.version_info < (2, 7):
@@ -162,8 +163,11 @@ class TestDevices(unittest.TestCase):
         if_name = "tap3e5a2b34222"
         proxy_targets = [IPAddress("2001::3:4"),
                          IPAddress("2001:3::4")]
-        with mock.patch('__builtin__.open', m_open, create=True), \
-             mock.patch('calico.felix.futils.check_call', return_value=rc) as m_check_call:
+
+        open_patch = mock.patch('__builtin__.open', m_open, create=True)
+        m_check_call = mock.patch('calico.felix.futils.check_call', return_value=rc)
+
+        with nested(open_patch, m_check_call) as (_, m_check_call):
             devices.configure_interface_ipv6(if_name, proxy_targets)
             calls = [mock.call('/proc/sys/net/ipv6/conf/%s/proxy_ndp' % if_name,
                                'wb'),

--- a/calico/felix/test/test_endpoint.py
+++ b/calico/felix/test/test_endpoint.py
@@ -246,14 +246,14 @@ class TestEndpoint(unittest.TestCase):
         self.assertEqual(len(ep.addresses), 2)
 
         # Set comprehension to get the 2 IP addresses
-        ips = {address.ip for address in ep.addresses.values()}
-        self.assertSetEqual(ips, {IPAddress("10.0.65.2"),
-                                  IPAddress("2001::3:4")})
+        ips = set(address.ip for address in ep.addresses.values())
+        self.assertSetEqual(ips, set([IPAddress("10.0.65.2"),
+                                      IPAddress("2001::3:4")]))
 
         # Set comprehension to get the gateways
-        gws = {address.gateway for address in ep.addresses.values()}
-        self.assertSetEqual(gws, {IPAddress("10.0.65.1"),
-                                  IPAddress("2001::1")})
+        gws = set(address.gateway for address in ep.addresses.values())
+        self.assertSetEqual(gws, set([IPAddress("10.0.65.1"),
+                                      IPAddress("2001::1")]))
 
     def test_store_update_2_addrs_repeated(self):
         """


### PR DESCRIPTION
These failures were introduced by #230.