### PR TITLE
Remove --wait flag from iptables.

### DIFF
--- a/calico/felix/fiptables.py
+++ b/calico/felix/fiptables.py
@@ -50,7 +50,6 @@ class Chain(object):
     def flush(self):
         log.debug("Flushing chain %s in table %s", self.name, self.table.desc)
         self.table.ops.append([IPTABLES_CMD[self.type],
-                               "--wait",
                                "--table",
                                self.table.name,
                                "--flush",
@@ -60,7 +59,6 @@ class Chain(object):
     def delete_rule(self, rule):
         # The rule must exist.
         args = [IPTABLES_CMD[self.type],
-                "--wait",
                 "--table",
                 self.table.name,
                 "--delete",
@@ -87,7 +85,6 @@ class Chain(object):
 
         while len(self.rules) > count:
             self.table.ops.append([IPTABLES_CMD[self.type],
-                                   "--wait",
                                    "--table",
                                    self.table.name,
                                    "--delete",
@@ -134,7 +131,6 @@ class Chain(object):
         """
         if position == RULE_POSN_LAST:
             args = [IPTABLES_CMD[self.type],
-                    "--wait",
                     "--table",
                     self.table.name,
                     "--append",
@@ -142,7 +138,6 @@ class Chain(object):
             self.rules.append(rule)
         else:
             args = [IPTABLES_CMD[self.type],
-                    "--wait",
                     "--table",
                     self.table.name,
                     "--insert",
@@ -207,7 +202,6 @@ class Table(object):
             chain.table = self
 
             self.ops.append([IPTABLES_CMD[self.type],
-                              "--wait",
                               "--table",
                               self.name,
                               "--new-chain",
@@ -220,7 +214,6 @@ class Table(object):
                   chain_name,
                   self.desc)
         self.ops.append([IPTABLES_CMD[self.type],
-                        "--wait",
                         "--table",
                         self.name,
                         "--delete-chain",
@@ -487,7 +480,6 @@ class TableState(object):
         purely for convenience of testing (since we can trivially mock it out).
         """
         data = futils.check_call([IPTABLES_CMD[type],
-                                  "--wait",
                                   "--list-rules",
                                   "--table",
                                   name]).stdout

--- a/calico/felix/test/test_fiptables.py
+++ b/calico/felix/test/test_fiptables.py
@@ -43,11 +43,11 @@ class TestFiptables(unittest.TestCase):
 
         with mock.patch('calico.felix.futils.check_call'):
             state.read_table(IPV4, "blah")
-            futils.check_call.assert_called_with(["iptables", "--wait", "--list-rules", "--table", "blah"])
+            futils.check_call.assert_called_with(["iptables", "--list-rules", "--table", "blah"])
 
         with mock.patch('calico.felix.futils.check_call'):
             state.read_table(IPV6, "blah")
-            futils.check_call.assert_called_with(["ip6tables", "--wait", "--list-rules", "--table", "blah"])
+            futils.check_call.assert_called_with(["ip6tables", "--list-rules", "--table", "blah"])
 
     def test_load_table(self):
         state = fiptables.TableState()
@@ -226,13 +226,12 @@ class TestFiptables(unittest.TestCase):
         self.assertEqual(mock_call.call_count, 1)
 
         ops = []
-        op = ["iptables", "--wait", "--table", "filter", "--insert", "FORWARD", "2"]
+        op = ["iptables", "--table", "filter", "--insert", "FORWARD", "2"]
         op.extend(rules[1].generate_fields())
         ops.append(op)
 
         for loop in range(0,6):
             ops.append(["iptables",
-                        "--wait",
                         "--table",
                         "filter",
                         "--delete",
@@ -310,7 +309,7 @@ class TestFiptables(unittest.TestCase):
         self.assertTrue(len(chain.rules), 1)
 
         # Set up a handy list of arguments
-        base_args = ["iptables", "--wait", "--table", "filter"]
+        base_args = ["iptables", "--table", "filter"]
 
         # Put a new rule at the start
         rule = fiptables.Rule(IPV4, "rule1")


### PR DESCRIPTION
Red Hat 6.5 does not have support for the `--wait` flag for iptables. Given that we're planning to switch to using `iptables-save` and `iptables-restore`, rather than individual iptables commands, the shortest sensible fix is to simple remove the `--wait` flag.

This'll give us one or two releases where we are *in principle* at risk of crashing Felix, but that's probably acceptable for unblocking RHEL 6.5.