### PR TITLE
Don't finish mechanism driver / ACL Manager audit until the initial GROUPUPDATEs have been sent

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -603,15 +603,6 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                     # It's a GETGROUPS request.
                     LOG.info("GETGROUPS request")
 
-                    # Send a GETGROUPS response, with no detail, on the ROUTER
-                    # socket.
-                    rsp = {'type': 'GETGROUPS'}
-                    LOG.info("Sending GETGROUPS response: %s" % rsp)
-                    self.acl_get_socket.send_multipart(
-                        [peer,
-                         '',
-                         json.dumps(rsp).encode('utf-8')])
-
                     # Set up access to the Neutron database, if we haven't
                     # already.
                     self._get_db()
@@ -623,6 +614,17 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                     # Send a GROUPUPDATE message for each group.
                     for sg in sgs:
                         self.send_group(sg, db_context)
+
+                    # Send a GETGROUPS response, with no detail, on the ROUTER
+                    # socket.  Do this after sending the start of day
+                    # GROUPUPDATEs so ACL Manager can detect if the audit
+                    # failed.
+                    rsp = {'type': 'GETGROUPS'}
+                    LOG.info("Sending GETGROUPS response: %s" % rsp)
+                    self.acl_get_socket.send_multipart(
+                        [peer,
+                         '',
+                         json.dumps(rsp).encode('utf-8')])
 
                 elif rq['type'] == 'HEARTBEAT':
                     # It's a heartbeat.  Send the same back.


### PR DESCRIPTION
ACL Manager needs to be able to detect audit failures and retry, which it can't do if the driver returns the GETGROUPS response immediately.

This is an fix to https://github.com/Metaswitch/calico/issues/255