### PR TITLE
Use a weakref to driver to break reference loops.

### DIFF
--- a/calico/openstack/transport.py
+++ b/calico/openstack/transport.py
@@ -20,6 +20,7 @@
 # Standard Python library imports.
 import abc
 import six
+import weakref
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -28,7 +29,11 @@ class CalicoTransport(object):
 
     def __init__(self, driver):
         super(CalicoTransport, self).__init__()
-        self.driver = driver
+
+        # Explicitly store the driver as a weakreference. This prevents
+        # the reference loop between transport and driver keeping the objects
+        # alive.
+        self.driver = weakref.proxy(driver)
 
     @abc.abstractmethod
     def initialize(self):


### PR DESCRIPTION
In the new model, the OpenStack ML2 driver stores a reference to one OpenStack Transport object. This transport object stores a reference back to its parent driver object, creating a reference loop.

This patch updates the transport to use a weak reference to the driver object. This should ensure that these objects can be promptly garbage collected if they go out of scope.

In practice, for these particular objects this isn't very likely, but it's still worth doing for the sake of correctness.