### PR TITLE
Fix broken link to architecture doc

### DIFF
--- a/docs/source/home.rst
+++ b/docs/source/home.rst
@@ -13,7 +13,7 @@ Architecture
 ------------
 
 Calico represents a new approach to virtual networking, based on the
-same scalable IP networking principles as the Internet. See :doc:`arch-overview`
+same scalable IP networking principles as the Internet. See :doc:`architecture`
 for an overview of how Calico works and what a Calico deployment
 contains.
 

--- a/docs/source/opens-install-inst.rst
+++ b/docs/source/opens-install-inst.rst
@@ -1,23 +1,25 @@
-Installation Instructions
-=========================
+Installing Calico and OpenStack
+===============================
 
-| These pages will guide you through installing Calico on your OpenStack
-| nodes. If you know nothing about OpenStack and just want to try out
-| Calico, you should consider the :doc:`opens-chef-install`
-| for Ubuntu 14.04. Otherwise, we support \* packaged install for Ubuntu
-| 14.04 - jump straight to :doc:`ubuntu-opens-install` to get started.
+If you know nothing about OpenStack and just want to try out
+Calico, you should consider the :doc:`opens-chef-install`
+which can be used on Ubuntu 14.04 to set up a Calico OpenStack system.
 
-| \* RPM install for Red Hat Enterprise Linux (RHEL 7) - see
-| :doc:`redhat-opens-install`.
+Otherwise, if you already use OpenStack, you can install Calico by using 
 
-All you need is at least two servers to get going.
+- the packaged install for Ubuntu 14.04 - see :doc:`ubuntu-opens-install`
+- an RPM install for Red Hat Enterprise Linux 7 (RHEL 7) - see :doc:`redhat-opens-install`.
+
+All you need is at least two servers to get going (one OpenStack controller and one
+OpenStack compute node).
 
 .. _opens-install-inst-next-steps:
 
 Next Steps
 ----------
 
-At this point you may wish to review the Calico configuration files and
+Once you have installed Calico onto an OpenStack system, 
+you may wish to review the Calico configuration files and
 make adjustments (such as to the logging targets and levels). The
 following article provides a reference to the available configuration
 options.


### PR DESCRIPTION
The link to the architecture doc is broken (it is pointing to a now deleted file).