### PR TITLE
Check interface state using flags, not operstate

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -140,8 +140,12 @@ def del_route(type, ip, interface):
 def interface_up(if_name):
     """
     Checks whether a given interface is up.
-    """
-    with open('/sys/class/net/%s/operstate' % if_name, 'r') as f:
-        state = f.read()
 
-    return 'up' in state
+    Checks this by examining the interface flags and looking for whether the
+    IFF_UP flag has been set. IFF_UP is the flag 0x01, so read in the flags
+    (represented by a hexadecimal integer) and check if the 1 bit is set.
+    """
+    with open('/sys/class/net/%s/flags' % if_name, 'r') as f:
+        flags = f.read().strip()
+
+    return bool(int(flags, 16) & 1)

--- a/calico/felix/test/test_devices.py
+++ b/calico/felix/test/test_devices.py
@@ -190,12 +190,12 @@ class TestDevices(unittest.TestCase):
         with mock.patch('__builtin__.open') as open_mock:
             open_mock.return_value = mock.MagicMock(spec=file)
             file_handle = open_mock.return_value.__enter__.return_value
-            file_handle.read.return_value = 'up\n'
+            file_handle.read.return_value = '0x1003\n'
 
             is_up = devices.interface_up(tap)
 
             open_mock.assert_called_with(
-                '/sys/class/net/%s/operstate' % tap, 'r'
+                '/sys/class/net/%s/flags' % tap, 'r'
             )
             self.assertTrue(file_handle.read.called)
             self.assertTrue(is_up)
@@ -209,12 +209,12 @@ class TestDevices(unittest.TestCase):
         with mock.patch('__builtin__.open') as open_mock:
             open_mock.return_value = mock.MagicMock(spec=file)
             file_handle = open_mock.return_value.__enter__.return_value
-            file_handle.read.return_value = 'down\n'
+            file_handle.read.return_value = '0x1002\n'
 
             is_up = devices.interface_up(tap)
 
             open_mock.assert_called_with(
-                '/sys/class/net/%s/operstate' % tap, 'r'
+                '/sys/class/net/%s/flags' % tap, 'r'
             )
             self.assertTrue(file_handle.read.called)
             self.assertFalse(is_up)


### PR DESCRIPTION
Sadly, operstate is basically always UNKNOWN for tap interfaces in RHEL 6.5, because of its stupid old kernel. This change checks whether IFF_UP is in the flags instead.