### PR TITLE
Fix small indentation and spelling mistakes in docs

### DIFF
--- a/docs/source/api-proposal.rst
+++ b/docs/source/api-proposal.rst
@@ -4,9 +4,9 @@ Calico API Design
 *Author's Note: This is a work in progress with some known issues. If
 something in this document strikes you as odd, please consult the list
 of outstanding issues at the bottom of the document before commenting.
-However, if it's not already mentioned, please do comment through our
-`mailing list <http://lists.projectcalico.org/listinfo/calico>`__ and
-`community <http://www.projectcalico.org/community/>`__. Feedback is
+However, if it's not already mentioned, please do comment through our*
+`mailing list <http://lists.projectcalico.org/listinfo/calico>`__ *and*
+`community <http://www.projectcalico.org/community/>`__. *Feedback is
 welcomed!*
 
 A simplified diagram of the current Calico architecture plan looks like

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -6,14 +6,14 @@ Features or any changes to the codebase should be done as follows:
 1. Pull latest code in the **master** branch and create a feature branch
    off this.
 
-2. Implement your feature. Commits are cheap in git, try to split up
-   your code into many, it makes reviewing easier as well as for saner
+2. Implement your feature. Commits are cheap in Git, try to split up
+   your code into many. It makes reviewing easier as well as for saner
    merging.
 
--  If your commit fixes an existing issue #123, include the text "fixes
-   #123" in at least one of your commit messages. This ensures the pull
-   request is attached to the existing issue
-   (http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github).
+   -  If your commit fixes an existing issue #123, include the text "fixes
+      #123" in at least one of your commit messages. This ensures the pull
+      request is attached to the existing issue
+      (see `How do you attach a new pull request to an existing issue on GitHub? <http://stackoverflow.com/questions/4528869/how-do-you-attach-a-new-pull-request-to-an-existing-issue-on-github>`__).
 
 3. Push your feature branch to GitHub.
 
@@ -21,28 +21,28 @@ Features or any changes to the codebase should be done as follows:
 
 5. Reviewer process:
 
--  Receive notice of review by Github email, Github notification, or by
-   checking `all your Metaswitch Github
-   issues <https://github.com/organizations/Metaswitch/dashboard/issues/assigned?direction=desc&state=open>`__.
--  Make markups as comments on the pull request (either line comments or
-   top-level comments).
--  Make a top-level comment saying something along the lines of “Fine;
-   some minor comments” or “Some issues to address before merging”.
--  If there are no issues, merge the pull request and close the branch.
-   Otherwise, assign the pull request to the developer and leave this to
-   them.
+   -  Receive notice of review by GitHub email, GitHub notification, or by
+      checking `all your Metaswitch GitHub
+      issues <https://github.com/organizations/Metaswitch/dashboard/issues/assigned?direction=desc&state=open>`__.
+   -  Make markups as comments on the pull request (either line comments or
+      top-level comments).
+   -  Make a top-level comment saying something along the lines of “Fine;
+      some minor comments” or “Some issues to address before merging”.
+   -  If there are no issues, merge the pull request and close the branch.
+      Otherwise, assign the pull request to the developer and leave this to
+      them.
 
 6. Developer process:
 
--  Await review.
--  Address code review issues on your feature branch.
--  Push your changes to the feature branch on GitHub. This automatically
-   updates the pull request.
--  If necessary, make a top-level comment along the lines of “Please
-   re-review”, assign back to the reviewer, and repeat the above.
--  If no further review is necessary and you have the necessary
-   privileges, merge the pull request and close the branch. Otherwise,
-   make a top-level comment and assign back to the reviewer as above.
+   -  Await review.
+   -  Address code review issues on your feature branch.
+   -  Push your changes to the feature branch on GitHub. This automatically
+      updates the pull request.
+   -  If necessary, make a top-level comment along the lines of “Please
+      re-review”, assign back to the reviewer, and repeat the above.
+   -  If no further review is necessary and you have the necessary
+      privileges, merge the pull request and close the branch. Otherwise,
+      make a top-level comment and assign back to the reviewer as above.
 
 Upcoming Changes
 ----------------

--- a/docs/source/ipv6.rst
+++ b/docs/source/ipv6.rst
@@ -42,20 +42,20 @@ snapshot thereafter instead of the original image.
 For example, starting from the Ubuntu 14.04 cloud image, the following
 changes will suffice to meet the requirements just listed.
 
--  In /etc/network/interfaces.d/eth0.cfg, add:
+-  In ``/etc/network/interfaces.d/eth0.cfg``, add:
 
    ::
 
        iface eth0 inet6 dhcp
                accept_ra 1
 
--  In /sbin/dhclient-script, add at the start of the script:
+-  In ``/sbin/dhclient-script``, add at the start of the script:
 
    ::
 
        new_ip6_prefixlen=128
 
--  In /etc/sysctl.d, create a file named 30-eth0-rs-delay.conf with
+-  In ``/etc/sysctl.d``, create a file named ``30-eth0-rs-delay.conf`` with
    contents:
 
    ::

--- a/docs/source/opens-chef-install.rst
+++ b/docs/source/opens-chef-install.rst
@@ -55,12 +55,15 @@ Prepare Your OpenStack Nodes
 The default Ubuntu 14.04 installation may have hosts configuration that
 causes problems for the Chef installation. We recommend ensuring the
 following preparation is performed on each OpenStack node prior to
-starting the bootstrap process: - Ensure your hostname is correctly set.
-Edit the /etc/hostname file and set the correct name for each node
-(names must be unique). - Ensure your loopback IP and OpenStack DNS
-entries are configured. Edit the /etc/hosts file: - Set the loopback IP
-address to 127.0.0.1. - Set your hostname IP address to your static IP.
-- Configure the hostnames / IPs of the other OpenStack nodes.
+starting the bootstrap process:
+
+   -  Ensure your hostname is correctly set. Edit the ``/etc/hostname`` file
+      and set the correct name for each node (names must be unique).
+   -  Ensure your loopback IP and OpenStack DNS entries are configured. Edit
+      the ``/etc/hosts`` file:
+         -  Set the loopback IP address to 127.0.0.1.
+         -  Set your hostname IP address to your static IP.
+   -  Configure the hostnames / IPs of the other OpenStack nodes.
 
 If you are using VMWare and VMs for each of these machines (for
 testing), ensure the VM setting allows the VM to expose hardware
@@ -148,15 +151,15 @@ up your deployment, perform the following steps:
 
 2. Bootstrap at least two further machines with the ``compute`` role.
 
-Note that this procedure works best when you assign all your compute
-machines the ``compute`` role *before* executing their run lists. This
-way you'll only need to execute the run list for each compute machine
-once.
+   Note that this procedure works best when you assign all your compute
+   machines the ``compute`` role *before* executing their run lists. This
+   way you'll only need to execute the run list for each compute machine
+   once.
 
-If you execute the run list for a compute machine before all the compute
-machines have been assigned their role, you'll need to re-run the
-run-list once all compute machines are present. The ``compute`` role
-builds up config that relies on knowing all the other ``compute`` nodes.
+   If you execute the run list for a compute machine before all the compute
+   machines have been assigned their role, you'll need to re-run the
+   run-list once all compute machines are present. The ``compute`` role
+   builds up config that relies on knowing all the other ``compute`` nodes.
 
 3. Play with Calico!
 

--- a/docs/source/overlap-ips.rst
+++ b/docs/source/overlap-ips.rst
@@ -12,13 +12,13 @@ different tenant.
 RFC 6877
 --------
 
-464XLAT is specified by https://tools.ietf.org/html/rfc6877 and
-describes how an IPv4-based application on a client device can access
+464XLAT is specified by `RFC 6877 <https://tools.ietf.org/html/rfc6877>`__
+and describes how an IPv4-based application on a client device can access
 IPv4-based services somewhere in the Internet, via an IPv6 network.
 
 -  An IPv4 packet sent from the client's application is translated
-   (statelessly, per https://tools.ietf.org/html/rfc6145) into an IPv6
-   packet.
+   (statelessly, per `RFC 6145 <https://tools.ietf.org/html/rfc6145>`__)
+   into an IPv6 packet.
 
    ::
 
@@ -30,7 +30,7 @@ IPv4-based services somewhere in the Internet, via an IPv6 network.
    server.
 
 -  The IPv6 packet is translated back into an IPv4 packet. This step
-   needs to be stateful (per https://tools.ietf.org/html/rfc6146)
+   needs to be stateful (per `RFC 6146 <https://tools.ietf.org/html/rfc6146>`__)
    because an arbitrary number of clients can connect to the server, and
    it isn't possible to map all their possible IPv6 addresses onto a
    range of IPv4 addresses in any way that's reversible without state.
@@ -112,7 +112,7 @@ There are many possible mappings between tenants and address spaces.
 -  Between these extremes, it is also possible for an address space to
    be shared by a specific group of tenants.
 
-Also note that a given tenant may use multiple address spaces - for
+Also note that a given tenant may use multiple address spaces – for
 example, one that is private to itself, and one that is shared.
 
 Compute host processing

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -111,41 +111,41 @@ Compute Node Install
 
 On a compute node, perform the following steps:
 
-1. Make the changes to SELinux and QEMU config that are described at
-   http://wiki.libvirt.org/page/Guest_won%27t_start_-_warning:_could_not_open_/dev/net/tun_%28%27generic_ethernet%27_interface%29,
+1. Make the changes to SELinux and QEMU config that are described in `this
+   libvirt Wiki page <http://wiki.libvirt.org/page/Guest_won%27t_start_-_warning:_could_not_open_/dev/net/tun_%28%27generic_ethernet%27_interface%29>`__,
    to allow VM interfaces with ``type='ethernet'``.
 
    ::
 
        setenforce permissive
 
-Edit ``/etc/selinux/config`` and change the ``SELINUX=`` line to the
-following:
+   Edit ``/etc/selinux/config`` and change the ``SELINUX=`` line to the
+   following:
 
-::
+   ::
 
-        SELINUX=permissive
+           SELINUX=permissive
 
-In ``/etc/libvirt/qemu.conf``, add or edit the following four options
-(in particular note the ``/dev/net/tun`` in ``cgroup_device_acl``):
+   In ``/etc/libvirt/qemu.conf``, add or edit the following four options
+   (in particular note the ``/dev/net/tun`` in ``cgroup_device_acl``):
 
-::
+   ::
 
-        clear_emulator_capabilities = 0
-        user = "root"
-        group = "root"
-        cgroup_device_acl = [
-             "/dev/null", "/dev/full", "/dev/zero",
-             "/dev/random", "/dev/urandom",
-             "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
-             "/dev/rtc", "/dev/hpet", "/dev/net/tun",
-        ]
+           clear_emulator_capabilities = 0
+           user = "root"
+           group = "root"
+           cgroup_device_acl = [
+                "/dev/null", "/dev/full", "/dev/zero",
+                "/dev/random", "/dev/urandom",
+                "/dev/ptmx", "/dev/kvm", "/dev/kqemu",
+                "/dev/rtc", "/dev/hpet", "/dev/net/tun",
+           ]
 
-Then restart libvirt to pick up the changes:
+   Then restart libvirt to pick up the changes:
 
-::
+   ::
 
-        service libvirtd restart
+           service libvirtd restart
 
 2. Open ``/etc/nova/nova.conf`` and remove the line that reads:
 
@@ -153,14 +153,14 @@ Then restart libvirt to pick up the changes:
 
        linuxnet_interface_driver = nova.network.linux_net.LinuxOVSInterfaceDriver
 
-Remove the line setting ``service_neutron_metadata_proxy`` or
-``service_metadata_proxy`` to ``True``, if there is one.
+   Remove the line setting ``service_neutron_metadata_proxy`` or
+   ``service_metadata_proxy`` to ``True``, if there is one.
 
-Restart nova compute.
+   Restart nova compute.
 
-::
+   ::
 
-        service openstack-nova-compute restart
+           service openstack-nova-compute restart
 
 3. If they're running, stop the Open vSwitch services:
 
@@ -169,12 +169,12 @@ Restart nova compute.
        service neutron-openvswitch-agent stop
        service openvswitch stop
 
-Then, prevent the services running if you reboot:
+   Then, prevent the services running if you reboot:
 
-::
+   ::
 
-        chkconfig openvswitch off
-        chkconfig neutron-openvswitch-agent off
+           chkconfig openvswitch off
+           chkconfig neutron-openvswitch-agent off
 
 4. Run ``yum update``. This will bring in Calico-specific updates to the
    OpenStack packages and to ``dnsmasq``.
@@ -191,12 +191,12 @@ Then, prevent the services running if you reboot:
 
        yum install openstack-neutron
 
-Open ``/etc/neutron/dhcp_agent.ini``. In the ``[DEFAULT]`` section, add
-the following line (removing any existing ``interface_driver =`` line):
+   Open ``/etc/neutron/dhcp_agent.ini``. In the ``[DEFAULT]`` section, add
+   the following line (removing any existing ``interface_driver =`` line):
 
-::
+   ::
 
-        interface_driver = neutron.agent.linux.interface.RoutedInterfaceDriver
+           interface_driver = neutron.agent.linux.interface.RoutedInterfaceDriver
 
 7.  Restart and enable the DHCP agent, and stop and disable the L3
     agent.
@@ -263,23 +263,23 @@ the following line (removing any existing ``interface_driver =`` line):
     Unless your deployment needs to peer with other BGP routers, this
     can be chosen arbitrarily.
 
-Note that you'll also need to configure your route reflector to allow
-connections from the compute node as a route reflector client. This
-configuration is outside the scope of this install document.
+   Note that you'll also need to configure your route reflector to allow
+   connections from the compute node as a route reflector client. This
+   configuration is outside the scope of this install document.
 
-Ensure BIRD (and/or BIRD 6 for IPv6) is running:
+   Ensure BIRD (and/or BIRD 6 for IPv6) is running:
 
-::
+   ::
 
-        service bird restart
-        service bird6 restart
+           service bird restart
+           service bird6 restart
 
-Finally ensure BIRD starts on reboot by running one or both of:
+   Finally ensure BIRD starts on reboot by running one or both of:
 
-::
+   ::
 
-        chkconfig bird on
-        chkconfig bird6 on
+           chkconfig bird on
+           chkconfig bird6 on
 
 12. Create the ``/etc/calico/felix.cfg`` file by copying
     ``/etc/calico/felix.cfg.example`` and edit it:

--- a/docs/source/security-model.rst
+++ b/docs/source/security-model.rst
@@ -17,7 +17,7 @@ then passes them over the Calico ACL API to the relevant Felix agent. That
 Felix agent then programs the rules into the kernel using ``iptables`` and
 ``ipsets`` commands.
 
-Security in OpenStack is controlled by 3 objects: networks, routers and
+Security in OpenStack is controlled by three objects: networks, routers and
 security groups. Calico **only** uses security groups for
 security configuration: networks and routers have no impact. The following
 subsections go into this in more detail, and discuss how these concepts map
@@ -29,7 +29,7 @@ Groups
 A security group is a collection of rules that may be applied to Neutron ports.
 The default action to perform on a packet (both in and outbound) is always
 DENY. In addition to the default rule, the user configures exceptions that
-allow traffic. These exceptioins carry the following information::
+allow traffic. These exceptions carry the following information::
 
     allow IPv4|IPv6 [<protocol> [<port range>]] traffic from/to <cidr>|<group>
 

--- a/docs/source/ubuntu-opens-install.rst
+++ b/docs/source/ubuntu-opens-install.rst
@@ -174,9 +174,9 @@ Compute Node Install
 
 On a compute node, perform the following steps:
 
-1. Make the changes to SELinux and QEMU config that are described at
-   http://wiki.libvirt.org/page/Guest\_won%27t\_start\_-\ *warning:*\ could\_not\_open\_/dev/net/tun\_%28%27generic\_ethernet%27\_interface%29,
-   to allow VM interfaces with type='ethernet'.
+1. Make the changes to SELinux and QEMU config that are described in
+   `this libvirt Wiki page <http://wiki.libvirt.org/page/Guest_won't_start_-_warning:_could_not_open_/dev/net/tun_('generic_ethernet'_interface)>`__,
+   to allow VM interfaces with ``type='ethernet'``.
 
    Disable SELinux if it's running. SELinux isn't installed by default
    on Ubuntu - you can check its status by running ``sestatus``. If this
@@ -211,14 +211,14 @@ On a compute node, perform the following steps:
 
        linuxnet_interface_driver = nova.network.linux_net.LinuxOVSInterfaceDriver
 
-Remove the line setting ``service_neutron_metadata_proxy`` or
-``service_metadata_proxy`` to ``True``, if there is one.
+   Remove the line setting ``service_neutron_metadata_proxy`` or
+   ``service_metadata_proxy`` to ``True``, if there is one.
 
-Restart nova compute.
+   Restart nova compute.
 
-::
+   ::
 
-        service nova-compute restart
+           service nova-compute restart
 
 3. If they're running, stop the Open vSwitch services:
 
@@ -227,13 +227,13 @@ Restart nova compute.
        service openvswitch-switch stop
        service neutron-plugin-openvswitch-agent stop
 
-Then, prevent the services running if you reboot:
+   Then, prevent the services running if you reboot:
 
-::
+   ::
 
-        sudo sh -c "echo 'manual' > /etc/init/openvswitch-switch.override"
-        sudo sh -c "echo 'manual' > /etc/init/openvswitch-force-reload-kmod.override"
-        sudo sh -c "echo 'manual' > /etc/init/neutron-plugin-openvswitch-agent.override"
+           sudo sh -c "echo 'manual' > /etc/init/openvswitch-switch.override"
+           sudo sh -c "echo 'manual' > /etc/init/openvswitch-force-reload-kmod.override"
+           sudo sh -c "echo 'manual' > /etc/init/neutron-plugin-openvswitch-agent.override"
 
 4. Install some extra packages.
 
@@ -264,8 +264,8 @@ Then, prevent the services running if you reboot:
 
        apt-get install calico-compute
 
-This step may prompt you to save your IPTables rules to make them
-persistent on restart - hit yes.
+   This step may prompt you to save your IPTables rules to make them
+   persistent on restart – hit yes.
 
 8. Configure BIRD. By default Calico assumes that you'll be deploying a
    route reflector to avoid the need for a full BGP mesh. To this end,
@@ -284,13 +284,13 @@ And/or for IPv6 connectivity between compute hosts:
 
         calico-gen-bird6-conf.sh <compute_node_ipv4> <compute_node_ipv6> <route_reflector_ipv6> <bgp_as_number>
 
-Note that you'll also need to configure your route reflector to allow
-connections from the compute node as a route reflector client. This
-configuration is outside the scope of this install document.
+   Note that you'll also need to configure your route reflector to allow
+   connections from the compute node as a route reflector client. This
+   configuration is outside the scope of this install document.
 
-If you *are* configuring a full BGP mesh you'll need to handle the BGP
-configuration appropriately. You should consult the relevant
-documentation for your chosen BGP stack.
+   If you *are* configuring a full BGP mesh you'll need to handle the BGP
+   configuration appropriately. You should consult the relevant
+   documentation for your chosen BGP stack.
 
 9.  Create the ``/etc/calico/felix.cfg`` file by taking a copy of the
     supplied sample config at ``/etc/calico/felix.cfg.example``. Then,


### PR DESCRIPTION
These are just minor fixes to the documentation. Other than the broken link, nothing here is particularly urgent.

From the commit message:

> *  Fixes one spelling error, a few capitalization mistakes, and
   one instance where a number was not fully spelt out.
> *  Fixes the indentation of follow-on list items.

>   Some list items (like this one) span multiple paragraphs. Every
   paragraph needs to be indented, or the rendered output does not
   indent them correctly.
*  Tidy up links: a couple were broken by escaping issues, and
   for others, I added a slightly more human-readable description
   instead of a raw URL.
*  Fix other small formatting bugs.

I haven’t run the unit tests, because these are only docs changes, but I did make a local copy of the docs to ensure my changes to the RST files were having the expected effect.

Note to reviewer: I'm a Metaswitch employee, but I haven't managed to associate myself with the Metaswitch GitHub organisation yet.