### PR TITLE
Neutron/zmq: Don't log a byte sequence that might not be a valid Unicode string

### DIFF
--- a/calico/openstack/t_zmq.py
+++ b/calico/openstack/t_zmq.py
@@ -184,7 +184,7 @@ class CalicoTransport0MQ(CalicoTransport):
                 # the message content.
                 peer = message[0]
                 rq = json.loads(message[2].decode('utf-8'))
-                LOG.info("Felix-ROUTER RX [%s] %s" % (peer, rq))
+                LOG.info("Felix-ROUTER RX %s" % rq)
 
                 if rq['type'] == 'RESYNCSTATE':
                     # It's a RESYNCSTATE request.
@@ -419,7 +419,7 @@ class CalicoTransport0MQ(CalicoTransport):
                 # the message content.
                 peer = message[0]
                 rq = json.loads(message[2].decode('utf-8'))
-                LOG.info("ACL-GET RX [%s] %s" % (peer, rq))
+                LOG.info("ACL-GET RX %s" % rq)
 
                 if rq['type'] == 'GETGROUPS':
                     # It's a GETGROUPS request.


### PR DESCRIPTION
This is to address exceptions like the following, seen on the controller in our Fuel clusters.

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/calico/openstack/t_zmq.py", line 187, in felix_router_thread
    LOG.info("Felix-ROUTER RX [%s] %s" % (peer, rq))
  File "/usr/lib/python2.7/logging/__init__.py", line 1420, in info
    self.logger.info(msg, *args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1140, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1258, in _log
    self.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1268, in handle
    self.callHandlers(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1308, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 748, in handle
    self.emit(record)
  File "/usr/lib/python2.7/logging/handlers.py", line 795, in emit
    msg = self.format(record) + '\000'
  File "/usr/lib/python2.7/dist-packages/neutron/openstack/common/log.py", line 502, in format
    msg = logging.handlers.SysLogHandler.format(self, record)
  File "/usr/lib/python2.7/logging/__init__.py", line 723, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/dist-packages/neutron/openstack/common/log.py", line 670, in format
    return logging.Formatter.format(self, record)
  File "/usr/lib/python2.7/logging/__init__.py", line 467, in format
    s = self._fmt % record.__dict__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcd in position 21: ordinal not in range(128)
