### PR TITLE
Neutron driver: reinstate start_flag reporting so web UI correctly shows...

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -247,16 +247,18 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         LOG.info("Endpoints for SG %s are %s" % (sg['id'], endpoints))
         return endpoints
 
-    def felix_status(self, hostname, up):
+    def felix_status(self, hostname, up, start_flag):
         # Get a DB context for this processing.
         db_context = ctx.get_admin_context()
 
         if up:
-            self.db.create_or_update_agent(db_context,
-                                           {'agent_type': AGENT_TYPE_FELIX,
-                                            'binary': '',
-                                            'host': hostname,
-                                            'topic': constants.L2_AGENT_TOPIC})
+            agent_state = {'agent_type': AGENT_TYPE_FELIX,
+                           'binary': '',
+                           'host': hostname,
+                           'topic': constants.L2_AGENT_TOPIC}
+            if start_flag:
+                agent_state['start_flag'] = True
+            self.db.create_or_update_agent(db_context, agent_state)
 
 
 class CalicoNotifierProxy(object):

--- a/calico/openstack/t_zmq.py
+++ b/calico/openstack/t_zmq.py
@@ -248,7 +248,7 @@ class CalicoTransport0MQ(CalicoTransport):
                 self.felix_peer_sockets[hostname] = sock
 
                 # Tell OpenStack that Felix on this host is up.
-                self.driver.felix_status(hostname, True)
+                self.driver.felix_status(hostname, True, True)
 
                 eventlet.spawn(self.felix_heartbeat_thread, hostname, sock)
             except:
@@ -396,7 +396,7 @@ class CalicoTransport0MQ(CalicoTransport):
                 return
 
             # Felix is still there, tell OpenStack.
-            self.driver.felix_status(hostname, True)
+            self.driver.felix_status(hostname, True, False)
 
     def acl_get_thread(self):
 

--- a/calico/openstack/test/test_plugin.py
+++ b/calico/openstack/test/test_plugin.py
@@ -560,7 +560,8 @@ class TestPlugin(unittest.TestCase):
                 {'agent_type': mech_calico.AGENT_TYPE_FELIX,
                  'binary': '',
                  'host': 'felix-host-1',
-                 'topic': mech_calico.constants.L2_AGENT_TOPIC})
+                 'topic': mech_calico.constants.L2_AGENT_TOPIC,
+                 'start_flag': True})
             self.db.create_or_update_agent.reset_mock()
 
         # Check RESYNCSTATE response was sent.


### PR DESCRIPTION
... Calico agent status