### PR TITLE
Bring forward changes from calico-docs.wiki

### DIFF
--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -13,7 +13,7 @@ Otherwise, if you already use OpenStack, you can install Calico by using
 
 - the packaged install for Ubuntu 14.04 - see :doc:`ubuntu-opens-install`
 
-- an RPM install for Red Hat Enterprise Linux 7 (RHEL 7) - see :doc:`redhat-opens-install`
+- an RPM install for Red Hat Enterprise Linux 7 (RHEL 7 or 6.5) - see :doc:`redhat-opens-install`
 
 - our experimental integration of Calico with Mirantis Fuel 5.1 - see :doc:`fuel-integration`.
 

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -318,17 +318,20 @@ On a compute node, perform the following steps:
 
    Ensure BIRD (and/or BIRD 6 for IPv6) is running and starts on reboot:
 
-   For RHEL 7::
+   - For RHEL 7:
 
-        service bird restart
-        service bird6 restart
+   ::
 
-        chkconfig bird on
-        chkconfig bird6 on
+       service bird restart
+       service bird6 restart
+       chkconfig bird on
+       chkconfig bird6 on
 
-    For RHEL 6.5::
+   - For RHEL 6.5:
 
-        initctl start bird
+   ::
+
+       initctl start bird
 
 12. Create the ``/etc/calico/felix.cfg`` file by copying
     ``/etc/calico/felix.cfg.example`` and edit it:
@@ -336,6 +339,7 @@ On a compute node, perform the following steps:
     -  Change the ``PluginAddress`` and ``ACLAddress`` settings to the
        host name or IP address of the controller node.
     -  Restart the Felix service:
+
        - on Red Hat 6.5, run ``initctl start calico-felix``.
        - on Red Hat 7, run ``systemctl restart calico-felix``.
 

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -13,9 +13,11 @@ Prerequisites
 Before starting this you will need the following:
 
 -  One or more machines running RHEL 6.5 or 7:
+
    - For RHEL 6.5, these machines should have OpenStack Icehouse installed on
      them.
    - For RHEL 7, these machines should have OpenStack Juno installed on them.
+
 -  SSH access to these machines.
 -  Working DNS between these machines (use ``/etc/hosts`` if you don't
    have DNS on your network).

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -1,5 +1,5 @@
-Red Hat Enterprise Linux 7 Packaged Install Instructions
-========================================================
+Red Hat Enterprise Linux 6.5/7 Packaged Install Instructions
+============================================================
 
 The instructions come in two sections: one for installing control nodes,
 and one for installing compute nodes. Before moving on to those
@@ -12,8 +12,10 @@ Prerequisites
 
 Before starting this you will need the following:
 
--  One or more machines running RHEL 7, with OpenStack Juno installed on
-   them.
+-  One or more machines running RHEL 6.5 or 7:
+   - For RHEL 6.5, these machines should have OpenStack Icehouse installed on
+     them.
+   - For RHEL 7, these machines should have OpenStack Juno installed on them.
 -  SSH access to these machines.
 -  Working DNS between these machines (use ``/etc/hosts`` if you don't
    have DNS on your network).
@@ -24,12 +26,12 @@ Common Steps
 Some steps need to be taken on all machines being installed with Calico.
 These steps are detailed here.
 
-Install OpenStack Juno
-~~~~~~~~~~~~~~~~~~~~~~
+Install OpenStack Icehouse/Juno
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you haven't already done so, install Juno with Neutron and ML2
-networking. Instructions for installing OpenStack on RHEL can be found
-`here <http://openstack.redhat.com/Main_Page>`__.
+If you haven't already done so, install Icehouse (RHEL 6.5) or Juno (RHEL 7)
+with Neutron and ML2 networking. Instructions for installing OpenStack on RHEL
+can be found `here <http://openstack.redhat.com/Main_Page>`__.
 
 Configure YUM repositories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -37,14 +39,27 @@ Configure YUM repositories
 As well as the repositories for OpenStack and EPEL
 (https://fedoraproject.org/wiki/EPEL) - which you will have already
 configured as part of the previous step - you will need to configure the
-repository for Calico:
+repository for Calico.
 
-::
+For RHEL 7::
 
     cat > /etc/yum.repos.d/calico.repo <<EOF
     [calico]
     name=Calico Repository
     baseurl=http://binaries.projectcalico.org/rpm/
+    enabled=1
+    skip_if_unavailable=0
+    gpgcheck=1
+    gpgkey=http://binaries.projectcalico.org/rpm/key
+    priority=97
+    EOF
+
+For RHEL 6.5::
+
+    cat > /etc/yum.repos.d/calico.repo <<EOF
+    [calico]
+    name=Calico Repository
+    baseurl=http://binaries.projectcalico.org/rhel6/
     enabled=1
     skip_if_unavailable=0
     gpgcheck=1
@@ -103,8 +118,10 @@ On a control node, perform the following steps:
    ``/etc/calico/acl_manager.cfg.example`` file and edit it:
 
    -  Change the ``PluginAddress`` to the host name or IP address of the
-      controller node. Then restart the ACL manager service with
-      ``service calico-acl-manager restart``.
+      controller node. Then restart the ACL manager service with:
+
+      - On Red Hat 6.5, ``initctl start calico-acl-manager``
+      - On Red Hat 7, ``systemctl restart calico-acl-manager``.
 
 Compute Node Install
 --------------------
@@ -218,11 +235,38 @@ On a compute node, perform the following steps:
         service openstack-nova-metadata-api restart
         chkconfig openstack-nova-metadata-api on
 
-9.  Install the BIRD BGP client:
+9.  For RHEL 7, install the BIRD BGP client from EPEL:
+    ``yum install -y bird bird6``. Then, go on to the next step.
+
+    For RHEL 6.5, BIRD needs to be built from source and installed manually.
+
+    First, download the source and build BIRD.
 
     ::
 
-        yum install -y bird bird6
+        yum install -y flex bison readline-devel ncurses-devel gcc wget
+        wget ftp://bird.network.cz/pub/bird/bird-1.4.5.tar.gz
+        tar xzvf bird-1.4.5.tar.gz
+        cd bird-1.4.5
+        ./configure
+        make
+        make install
+
+    Now, create the upstart job file for BIRD by putting the following in
+    ``/etc/init/bird.conf``
+
+    ::
+
+        description "BIRD Internet Routing Daemon"
+        start on runlevel [2345]
+        stop on runlevel [016]
+        respawn
+        pre-start script
+        /usr/local/sbin/bird -p -c /etc/bird/bird.conf
+        end script
+        script
+        /usr/local/sbin/bird -f -c /etc/bird/bird.conf
+        end script
 
 10. Install the ``calico-compute`` package:
 
@@ -263,30 +307,35 @@ On a compute node, perform the following steps:
     Unless your deployment needs to peer with other BGP routers, this
     can be chosen arbitrarily.
 
+    For RHEL 6.5, ignore any ``bird: unrecognized service`` error - we'll
+    restart BIRD later anyway.
+
    Note that you'll also need to configure your route reflector to allow
    connections from the compute node as a route reflector client. This
    configuration is outside the scope of this install document.
 
-   Ensure BIRD (and/or BIRD 6 for IPv6) is running:
+   Ensure BIRD (and/or BIRD 6 for IPv6) is running and starts on reboot:
 
-   ::
+   For RHEL 7::
 
-           service bird restart
-           service bird6 restart
+        service bird restart
+        service bird6 restart
 
-   Finally ensure BIRD starts on reboot by running one or both of:
+        chkconfig bird on
+        chkconfig bird6 on
 
-   ::
+    For RHEL 6.5::
 
-           chkconfig bird on
-           chkconfig bird6 on
+        initctl start bird
 
 12. Create the ``/etc/calico/felix.cfg`` file by copying
     ``/etc/calico/felix.cfg.example`` and edit it:
 
     -  Change the ``PluginAddress`` and ``ACLAddress`` settings to the
        host name or IP address of the controller node.
-    -  Restart the Felix service with ``service calico-felix restart``.
+    -  Restart the Felix service:
+       - on Red Hat 6.5, run ``initctl start calico-felix``.
+       - on Red Hat 7, run ``systemctl restart calico-felix``.
 
 Next Steps
 ----------

--- a/docs/source/verification.rst
+++ b/docs/source/verification.rst
@@ -82,6 +82,14 @@ deployment is in good shape.
 Troubleshooting
 ---------------
 
+If you find that none of the advice below solves your problems, please use our
+diagnostics gathering script to generate diagnostics, and then raise a GitHub
+issue against our repository. To generate the diags, run
+
+.. code-block:: bash
+
+    $ /usr/bin/calico-diags
+
 VMs cannot DHCP
 ~~~~~~~~~~~~~~~
 
@@ -93,16 +101,16 @@ something that looks a bit like this:
 ::
 
     Chain INPUT (policy ACCEPT)
-    target     prot opt source               destination         
-    ACCEPT     all  --  anywhere             anywhere            state RELATED,ESTABLISHED 
-    ACCEPT     icmp --  anywhere             anywhere            
-    ACCEPT     all  --  anywhere             anywhere            
-    ACCEPT     tcp  --  anywhere             anywhere            state NEW tcp dpt:ssh 
-    REJECT     all  --  anywhere             anywhere            reject-with icmp-host-prohibited 
+    target     prot opt source               destination
+    ACCEPT     all  --  anywhere             anywhere            state RELATED,ESTABLISHED
+    ACCEPT     icmp --  anywhere             anywhere
+    ACCEPT     all  --  anywhere             anywhere
+    ACCEPT     tcp  --  anywhere             anywhere            state NEW tcp dpt:ssh
+    REJECT     all  --  anywhere             anywhere            reject-with icmp-host-prohibited
 
     Chain FORWARD (policy ACCEPT)
-    target     prot opt source               destination         
-    REJECT     all  --  anywhere             anywhere            reject-with icmp-host-prohibited 
+    target     prot opt source               destination
+    REJECT     all  --  anywhere             anywhere            reject-with icmp-host-prohibited
 
     Chain OUTPUT (policy ACCEPT)
     target     prot opt source               destination


### PR DESCRIPTION
This should bring forward all changes made to the Calico docs wiki since the last time we synchronized them.