### PR TITLE
Implementation and UT for etcd transport for plugin (aka Neutron driver)

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -147,6 +147,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         if self._port_is_endpoint_port(port):
             LOG.info("Updated port: %s" % port)
             LOG.info("Original: %s" % original)
+
             if port['binding:vif_type'] == 'unbound':
                 # This indicates part 1 of a port being migrated: the port
                 # being unbound from its old location.  The old compute host is
@@ -157,6 +158,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 # 2014-February/027571.html
                 LOG.info("Migration part 1")
                 self.add_port_gateways(original, context._plugin_context)
+                self.add_port_interface_name(original)
                 self.transport.endpoint_deleted(original)
             elif original['binding:vif_type'] == 'unbound':
                 # This indicates part 2 of a port being migrated: the port
@@ -167,17 +169,21 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 # 2014-February/027571.html
                 LOG.info("Migration part 2")
                 self.add_port_gateways(port, context._plugin_context)
+                self.add_port_interface_name(port)
                 self.transport.endpoint_created(port)
             elif original['binding:host_id'] != port['binding:host_id']:
                 # Migration as implemented in Icehouse.
                 LOG.info("Migration as implemented in Icehouse")
                 self.add_port_gateways(original, context._plugin_context)
+                self.add_port_interface_name(original)
                 self.transport.endpoint_deleted(original)
                 self.add_port_gateways(port, context._plugin_context)
+                self.add_port_interface_name(port)
                 self.transport.endpoint_created(port)
             else:
                 # This is a non-migration-related update.
                 self.add_port_gateways(port, context._plugin_context)
+                self.add_port_interface_name(port)
                 self.transport.endpoint_updated(port)
 
     def delete_port_postcommit(self, context):

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -225,7 +225,7 @@ class CalicoTransportEtcd(CalicoTransport):
 
                 # Map the protocol field from Neutron to etcd format.
                 if rule['protocol'] is None:
-                    raise UnsupportedError('protocol None')
+                    pass
                 elif rule['protocol'] == 'icmp':
                     etcd_rule['protocol'] = {'IPv4': 'icmp',
                                              'IPv6': 'icmpv6'}[ethertype]

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -29,6 +29,8 @@ from calico.openstack.transport import CalicoTransport
 
 LOG = None
 
+PERIODIC_RESYNC_INTERVAL_SECS = 30
+
 
 class CalicoTransportEtcd(CalicoTransport):
     """Calico transport implementation based on etcd."""

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -154,6 +154,7 @@ class CalicoTransportEtcd(CalicoTransport):
         return data
 
     def port_profile_id(self, port):
+        return '_'.join(port['security_groups'])
 
     def resync_security_groups(self):
 

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -17,6 +17,13 @@
 
 # Etcd-based transport for the Calico/OpenStack Plugin.
 
+# Standard Python library imports.
+import etcd
+import eventlet
+import json
+import re
+import time
+
 # Calico imports.
 from calico.openstack.transport import CalicoTransport
 
@@ -26,6 +33,9 @@ LOG = None
 class CalicoTransportEtcd(CalicoTransport):
     """Calico transport implementation based on etcd."""
 
+    OPENSTACK_ENDPOINT_RE = re.compile(
+    r'^/calico/host/(?P<hostname>[^/]+)/.*openstack.*/endpoint/(?P<endpoint_id>[^/]+)')
+
     def __init__(self, driver, logger):
         super(CalicoTransportEtcd, self).__init__(driver)
 
@@ -34,7 +44,118 @@ class CalicoTransportEtcd(CalicoTransport):
         LOG = logger
 
     def initialize(self):
-        pass
+        # Prepare client for accessing etcd data.
+        self.client = etcd.Client()
+
+        # Spawn a green thread for periodically resynchronizing etcd against
+        # the OpenStack database.
+        eventlet.spawn(self.periodic_resync_thread)
+
+    def periodic_resync_thread(self):
+        while True:
+            try:
+                # Resynchronize endpoint data.
+                self.resync_endpoints()
+
+                # Resynchronize security group data.
+                self.resync_security_groups()
+
+                # Sleep until time for next resync.
+                eventlet.sleep(PERIODIC_RESYNC_INTERVAL_SECS)
+
+            except:
+                LOG.exception("Exception in periodic resync thread")
+
+    def resync_endpoints(self):
+        # Get all current endpoints from the OpenStack database and key them on
+        # endpoint ID.
+        ports = {}
+        for port in self.driver.get_endpoints():
+            ports[port['id']] = port
+
+        # Read all etcd keys under /calico/host.
+        r = client.read('/calico/host', recursive=True)
+        for child in r.children:
+            m = OPENSTACK_ENDPOINT_RE.match(child.key)
+            if m:
+                # We have a key/value pair for an OpenStack endpoint.  Extract
+                # the endpoint ID and hostname from the key, and read the JSON
+                # data as a dict.
+                id = m.group("endpoint_id")
+                hostname = m.group("hostname")
+                data = json_decoder.decode(child.value)
+
+                if id in ports:
+                    # OpenStack still has an endpoint with this ID.
+                    new_data = self.port_etcd_value(ports[id])
+
+                    if ports[id]['binding:host_id'] == hostname:
+                        # The endpoint's current host matches the etcd key.
+                        if data == new_data:
+                            # The endpoint data is unchanged.  No change
+                            # needed.
+                            pass
+                        else:
+                            # The endpoint data has changed, so we should
+                            # rewrite it.
+                            client.write(child.key, json.dumps(new_data))
+                    else:
+                        # The endpoint has moved to a new host.  We should
+                        # delete the old key and create a new one with the new
+                        # hostname.
+                        client.delete(child.key)
+                        client.write(self.port_etcd_key(ports[id]), new_data)
+
+                    # This OpenStack port is now correctly reflected in etcd,
+                    # so we won't need to process it again below.
+                    del ports[id]
+                else:
+                    # OpenStack no longer wants an endpoint with this ID, so we
+                    # should delete the etcd key.
+                    client.delete(child.key)
+
+        # Now create etcd data for any endpoints remaining in the ports dict;
+        # these are new endpoints - i.e. never previously represented in etcd
+        # data.
+        for port in ports.values:
+            client.write(self.port_etcd_key(port), self.port_etcd_data(port))
+
+    def port_etcd_key(self, port):
+        return "/calico/host/%s/workload/openstack/endpoint/%s" % (
+            port['binding:host_id'],
+            port['id']
+        )
+
+    def port_etcd_data(self, port):
+        # Construct the simpler port data.
+        data = {'state': 'active' if port['admin_state_up'] else 'inactive',
+                'name': port['interface_name'],
+                'mac': port['mac_address'],
+                'profile_id': self.port_profile_id(port)}
+
+        # Collect IPv6 and IPv6 addresses.  On the way, also set the
+        # corresponding gateway fields.  If there is more than one IPv4 or IPv6
+        # gateway, the last one (in port['fixed_ips']) wins.
+        ipv4_nets = []
+        ipv6_nets = []
+        for ip in port['fixed_ips']:
+            if ':' in ip['ip_address']:
+                ipv6_nets.append(ip['ip_address'] + '/128')
+                if ip['gateway'] is not None:
+                    data['ipv6_gateway'] = ip['gateway']
+            else:
+                ipv4_nets.append(ip['ip_address'] + '/32')
+                if ip['gateway'] is not None:
+                    data['ipv4_gateway'] = ip['gateway']
+        data['ipv4_nets'] = ipv4_nets
+        data['ipv6_nets'] = ipv6_nets
+
+        # Return that data.
+        return data
+
+    def port_profile_id(self, port):
+
+    def resync_security_groups(self):
 
     def endpoint_created(self, port):
         pass

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -116,7 +116,7 @@ class CalicoTransportEtcd(CalicoTransport):
         # data - or endpoints that have migrated or whose data has changed.
         for port in ports.values:
             data = self.port_etcd_data(port)
-            client.write(self.port_etcd_key(port), data)
+            client.write(self.port_etcd_key(port), json.dumps(data))
 
             # Remember the security profile that this port needs.
             needed_profiles.add(data['profile_id'])
@@ -193,8 +193,10 @@ class CalicoTransportEtcd(CalicoTransport):
         # Now write etcd data for each profile remaining in needed_profiles.
         for profile_id in needed_profiles:
             key = '/calico/policy/profile/' + profile_id
-            client.write(key + '/rules', self.profile_rules(profile_id, sgs))
-            client.write(key + '/tags', self.profile_tags(profile_id))
+            client.write(key + '/rules',
+                         json.dumps(self.profile_rules(profile_id, sgs)))
+            client.write(key + '/tags',
+                         json.dumps(self.profile_tags(profile_id)))
 
     def profile_rules(self, profile_id, sgs):
         inbound = []

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -31,7 +31,7 @@ LOG = None
 OPENSTACK_ENDPOINT_RE = re.compile(
     r'^/calico/host/(?P<hostname>[^/]+)/.*openstack.*/endpoint/(?P<endpoint_id>[^/]+)')
 OPENSTACK_POLICY_RE = re.compile(
-    r'^/calico/policy/profile/(?P<profile_id>[^/]+)')
+    r'^/calico/policy/profile/(?P<profile_id>[^/]+)/tags')
 
 json_decoder = json.JSONDecoder()
 

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -184,7 +184,7 @@ class CalicoTransportEtcd(CalicoTransport):
         correct_profiles = set()
 
         # Read all etcd keys directly under /calico/policy/profile.
-        r = self.client.read('/calico/policy/profile')
+        r = self.client.read('/calico/policy/profile', recursive=True)
         for child in r.children:
             m = OPENSTACK_POLICY_RE.match(child.key)
             if m:

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -237,7 +237,7 @@ class CalicoTransportEtcd(CalicoTransport):
         outbound = []
         for sgid in self.profile_tags(profile_id):
             for rule in self.sgs[sgid]['security_group_rules']:
-                LOG.info("Neutron rule %s" % rule)
+                LOG.info("Neutron rule  %s : %s", profile_id, rule)
 
                 ethertype = rule['ethertype']
                 etcd_rule = {}

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -309,7 +309,12 @@ class CalicoTransportEtcd(CalicoTransport):
 
     def endpoint_deleted(self, port):
         # Delete the etcd key for this endpoint.
-        self.client.delete(self.port_etcd_key(port))
+        key = self.port_etcd_key(port)
+        try:
+            self.client.delete(key)
+        except KeyError:
+            # Etcd returned a KeyError; doesn't exist, so treat as success
+            pass
 
     def security_group_updated(self, sg):
         # Update the data that we're keeping for this security group.

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -75,11 +75,11 @@ class CalicoTransportEtcd(CalicoTransport):
                 # Resynchronize security group data.
                 self.resync_security_groups()
 
-                # Sleep until time for next resync.
-                eventlet.sleep(PERIODIC_RESYNC_INTERVAL_SECS)
-
             except:
                 LOG.exception("Exception in periodic resync thread")
+
+            # Sleep until time for next resync.
+            eventlet.sleep(PERIODIC_RESYNC_INTERVAL_SECS)
 
     def resync_endpoints(self):
         # Get all current endpoints from the OpenStack database and key them on

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -264,25 +264,28 @@ class CalicoTransportEtcd(CalicoTransport):
                 # src/dst_ports is a list in which each entry can be a single
                 # number, or a string describing a port range.
                 if rule['port_range_min'] == -1:
-                    port_spec = '1:65535'
+                    port_spec = ['1:65535']
                 elif rule['port_range_min'] == rule['port_range_max']:
-                    port_spec = rule['port_range_min']
+                    if rule['port_range_min'] is not None:
+                        port_spec = [rule['port_range_min']]
+                    else:
+                        port_spec = None
                 else:
-                    port_spec = '%s:%s' % (rule['port_range_min'],
-                                           rule['port_range_max'])
+                    port_spec = ['%s:%s' % (rule['port_range_min'],
+                                            rule['port_range_max'])]
 
                 # Put it all together and add to either the inbound or the
                 # outbound list.
                 if rule['direction'] == 'ingress':
                     etcd_rule['src_tag'] = rule['remote_group_id']
                     etcd_rule['src_net'] = net
-                    etcd_rule['src_ports'] = [port_spec]
+                    etcd_rule['src_ports'] = port_spec
                     inbound.append(etcd_rule)
                     LOG.info("=> Inbound Calico rule %s" % etcd_rule)
                 else:
                     etcd_rule['dst_tag'] = rule['remote_group_id']
                     etcd_rule['dst_net'] = net
-                    etcd_rule['dst_ports'] = [port_spec]
+                    etcd_rule['dst_ports'] = port_spec
                     outbound.append(etcd_rule)
                     LOG.info("=> Outbound Calico rule %s" % etcd_rule)
 

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -219,20 +219,20 @@ class Lib(object):
         """Setup to intercept and display logging by the code under test.
         """
         # Print logs to stdout.
-        def log_info(msg):
-            print "       INFO %s" % msg
+        def log_info(msg, *args):
+            print "       INFO %s" % (msg % args)
             return None
-        def log_debug(msg):
-            print "       DEBUG %s" % msg
+        def log_debug(msg, *args):
+            print "       DEBUG %s" % (msg % args)
             return None
-        def log_warn(msg):
-            print "       WARN %s" % msg
+        def log_warn(msg, *args):
+            print "       WARN %s" % (msg % args)
             return None
-        def log_error(msg):
-            print "       ERROR %s" % msg
+        def log_error(msg, *args):
+            print "       ERROR %s" % (msg % args)
             return None
-        def log_exception(msg):
-            print "       EXCEPTION %s" % msg
+        def log_exception(msg, *args):
+            print "       EXCEPTION %s" % (msg % args)
             if sys.exc_type is not greenlet.GreenletExit:
                 traceback.print_exc()
             return None

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+openstack.test.lib
+~~~~~~~~~~~
+
+Common code for Neutron driver UT.
+"""
+import mock
+import sys
+
+sys.modules['neutron'] = m_neutron = mock.Mock()
+sys.modules['neutron.common'] = m_neutron.common
+sys.modules['neutron.openstack'] = m_neutron.openstack
+sys.modules['neutron.openstack.common'] = m_neutron.openstack.common
+sys.modules['neutron.plugins'] = m_neutron.plugins
+sys.modules['neutron.plugins.ml2'] = m_neutron.plugins.ml2
+sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
+sys.modules['etcd'] = m_etcd = mock.Mock()
+
+
+# Define a stub class, that we will use as the base class for
+# CalicoMechanismDriver.
+class DriverBase(object):
+    def __init__(self, agent_type, vif_type, vif_details):
+        pass
+
+# Replace Neutron's SimpleAgentMechanismDriverBase - which is the base class
+# that CalicoMechanismDriver inherits from - with this stub class.
+m_neutron.plugins.ml2.drivers.mech_agent.SimpleAgentMechanismDriverBase = \
+    DriverBase
+
+import calico.openstack.mech_calico as mech_calico
+
+
+class Lib(object):
+
+    # Ports to return when the driver asks the OpenStack database for all
+    # current ports.
+    osdb_ports = []
+
+    def setUp(self):
+        # Create an instance of CalicoMechanismDriver.
+        self.driver = mech_calico.CalicoMechanismDriver()
+
+        # Hook the (mock) Neutron database.
+        self.db = mech_calico.manager.NeutronManager.get_plugin()
+        self.db_context = mech_calico.ctx.get_admin_context()
+
+        # Arrange what the DB's get_ports will return.
+        self.db.get_ports.return_value = self.osdb_ports

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -98,7 +98,7 @@ class Lib(object):
         self.setUp_logging()
 
         # If an arg mismatch occurs, we want to see the complete diff of it.
-        self.maxDiff = 2000
+        self.maxDiff = None
 
         # Create an instance of CalicoMechanismDriver.
         self.driver = mech_calico.CalicoMechanismDriver()
@@ -301,3 +301,10 @@ class Lib(object):
         to run.
         """
         self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+
+    def check_update_port_status_called(self, context):
+        self.db.update_port_status.assert_called_once_with(
+            context._plugin_context,
+            context._port['id'],
+            mech_calico.constants.PORT_STATUS_ACTIVE)
+        self.db.update_port_status.reset_mock()

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -98,7 +98,7 @@ class Lib(object):
         self.setUp_logging()
 
         # If an arg mismatch occurs, we want to see the complete diff of it.
-        self.maxDiff = 1000
+        self.maxDiff = 2000
 
         # Create an instance of CalicoMechanismDriver.
         self.driver = mech_calico.CalicoMechanismDriver()

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -23,6 +23,10 @@ import mock
 import sys
 import traceback
 
+if 'zmq' in sys.modules:
+    del sys.modules['zmq']
+
+sys.modules['etcd'] = m_etcd = mock.Mock()
 sys.modules['neutron'] = m_neutron = mock.Mock()
 sys.modules['neutron.common'] = m_neutron.common
 sys.modules['neutron.openstack'] = m_neutron.openstack
@@ -30,7 +34,9 @@ sys.modules['neutron.openstack.common'] = m_neutron.openstack.common
 sys.modules['neutron.plugins'] = m_neutron.plugins
 sys.modules['neutron.plugins.ml2'] = m_neutron.plugins.ml2
 sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
-sys.modules['etcd'] = m_etcd = mock.Mock()
+sys.modules['oslo'] = m_oslo = mock.Mock()
+sys.modules['oslo.config'] = m_oslo.config
+sys.modules['time'] = m_time = mock.Mock()
 
 port1 = {'binding:vif_type': 'tap',
          'binding:host_id': 'felix-host-1',

--- a/calico/openstack/test/test_plugin.py
+++ b/calico/openstack/test/test_plugin.py
@@ -44,6 +44,7 @@ sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
 sys.modules['oslo'] = m_oslo = mock.Mock()
 sys.modules['oslo.config'] = m_oslo.config
 sys.modules['time'] = m_time = mock.Mock()
+sys.modules['etcd'] = m_etcd = mock.Mock()
 
 
 # Define a stub class, that we will use as the base class for
@@ -403,6 +404,10 @@ class TestPlugin(unittest.TestCase):
 
         # Create an instance of CalicoMechanismDriver.
         self.driver = mech_calico.CalicoMechanismDriver()
+
+        # Use 0MQ transport.
+        self.driver.transport = t_zmq.CalicoTransport0MQ(self.driver,
+                                                         mech_calico.LOG)
 
     # Tear down after each test case.
     def tearDown(self):

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -56,20 +56,24 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         else:
             read_result.value = None
 
+        # Print and return the result object.
+        print "etcd read: %s\nvalue: %s" % (key, read_result.value)
+
         if recursive:
             # Also see if this key has any children, and read those.
-            child_keys = set()
+            read_result.children = []
             keylen = len(key) + 1
             for k in self.etcd_data.keys():
                 if k[:keylen] == key + '/':
-                    child_keys.add(key + '/' + k[keylen:].split('/')[0])
-            read_result.children = [self.etcd_read(child_key, True)
-                                    for child_key in child_keys]
+                    child = mock.Mock()
+                    child.key = k
+                    child.value = self.etcd_data[k]
+                    read_result.children.append(child)
+            print "children: %s" % [child.key
+                                    for child in read_result.children]
+        else:
+            read_result.children = None
 
-        # Print and return the result object.
-        print "etcd read: %s\n%s\n%s" % (key,
-                                         read_result.value,
-                                         read_result.children)
         return read_result
 
     def setUp(self):

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+openstack.test.test_plugin_etcd
+~~~~~~~~~~~
+
+Unit test for the Calico/OpenStack Plugin using etcd transport.
+"""
+import unittest
+
+import calico.openstack.test.lib as lib
+import calico.openstack.mech_calico as mech_calico
+
+
+class TestPluginEtcd(lib.Lib, unittest.TestCase):
+
+    # Setup before each test case (= each method below whose name begins with
+    # "test").
+    def setUp(self):
+        super(TestPluginEtcd, self).setUp()
+
+    def start_of_day(self):
+        # Tell the driver to initialize.
+        self.driver.initialize()
+
+    # Mainline test.
+    def test_mainline(self):
+        # Start of day processing: initialization and socket binding.
+        self.start_of_day()

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -62,7 +62,8 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         self.driver.initialize()
 
         # Allow the etcd transport's resync thread to run.
-        eventlet.sleep(1)
+        self.give_way()
+        self.simulated_time_advance(1)
 
     def test_start_two_ports(self):
         """Startup with two existing ports but no existing etcd data.
@@ -77,4 +78,4 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         self.driver.initialize()
 
         # Allow the etcd transport's resync thread to run.
-        eventlet.sleep(1)
+        self.give_way()

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -24,6 +24,7 @@ import unittest
 
 import calico.openstack.test.lib as lib
 import calico.openstack.mech_calico as mech_calico
+import calico.openstack.t_etcd as t_etcd
 
 
 class TestPluginEtcd(lib.Lib, unittest.TestCase):
@@ -38,6 +39,10 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         """
         # Do common plugin test setup.
         super(TestPluginEtcd, self).setUp()
+
+        # Use etcd transport instead of 0MQ.
+        self.driver.transport = t_etcd.CalicoTransportEtcd(self.driver,
+                                                           mech_calico.LOG)
 
         # Hook the (mock) etcd client.
         self.client = lib.m_etcd.Client()

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -18,6 +18,7 @@ openstack.test.test_plugin_etcd
 
 Unit test for the Calico/OpenStack Plugin using etcd transport.
 """
+import mock
 import unittest
 
 import calico.openstack.test.lib as lib
@@ -26,16 +27,30 @@ import calico.openstack.mech_calico as mech_calico
 
 class TestPluginEtcd(lib.Lib, unittest.TestCase):
 
-    # Setup before each test case (= each method below whose name begins with
-    # "test").
+    def check_etcd_write(self, key, value):
+        """Print each etcd write as it occurs.
+        """
+        print "etcd write: %s\n%s" % (key, value)
+
     def setUp(self):
+        """Setup before each test case.
+        """
+        # Do common plugin test setup.
         super(TestPluginEtcd, self).setUp()
 
-    def start_of_day(self):
+        # Hook the (mock) etcd client.
+        self.client = lib.m_etcd.Client()
+        self.client.write.side_effect = self.check_etcd_write
+
+        # Prepare an empty read object.
+        self.empty_read = mock.Mock()
+        self.empty_read.children = []
+
+    def test_start_no_ports(self):
+        """Startup with no ports or existing etcd data.
+        """
+        # Arrange for etcd reads to return nothing.
+        self.client.read.return_value = self.empty_read
+
         # Tell the driver to initialize.
         self.driver.initialize()
-
-    # Mainline test.
-    def test_mainline(self):
-        # Start of day processing: initialization and socket binding.
-        self.start_of_day()

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -18,6 +18,7 @@ openstack.test.test_plugin_etcd
 
 Unit test for the Calico/OpenStack Plugin using etcd transport.
 """
+import eventlet
 import mock
 import unittest
 
@@ -54,3 +55,21 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
 
         # Tell the driver to initialize.
         self.driver.initialize()
+
+        # Allow the etcd transport's resync thread to run.
+        eventlet.sleep(1)
+
+    def test_start_two_ports(self):
+        """Startup with two existing ports but no existing etcd data.
+        """
+        # Arrange for etcd reads to return nothing.
+        self.client.read.return_value = self.empty_read
+
+        # Provide two Neutron ports.
+        self.osdb_ports = [lib.port1, lib.port2]
+
+        # Tell the driver to initialize.
+        self.driver.initialize()
+
+        # Allow the etcd transport's resync thread to run.
+        eventlet.sleep(1)

--- a/calico/openstack/test/test_plugin_zmq.py
+++ b/calico/openstack/test/test_plugin_zmq.py
@@ -47,11 +47,7 @@ TIMEOUT_VALUE = object()
 
 class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-
-        global real_eventlet_sleep
-        global real_eventlet_spawn
+    def setUpEventlet(self):
 
         # Replacement for eventlet.sleep: sleep for some simulated passage of
         # time (as directed by simulated_time_advance), instead of for real
@@ -63,14 +59,14 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
             queue.stack = inspect.stack()[1][3]
 
             # Add it to the dict of sleepers, together with the waking up time.
-            sleepers[queue] = current_time + secs
+            self.sleepers[queue] = self.current_time + secs
 
             print "T=%s: %s: Start sleep for %ss until T=%s" % (
-                current_time, queue.stack, secs, sleepers[queue]
+                self.current_time, queue.stack, secs, self.sleepers[queue]
             )
 
             # Do a zero time real sleep, to allow other threads to run.
-            real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+            self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
             # Block until something is posted to the queue.
             ignored = queue.get(True)
@@ -83,28 +79,27 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         def simulated_spawn(*args):
 
             # Do the real spawn.
-            thread = real_eventlet_spawn(*args)
+            thread = self.real_eventlet_spawn(*args)
 
             # Remember this thread.
-            threads.append(thread)
+            self.threads.append(thread)
 
             # Also return it.
             return thread
 
-        # Hook sleeping.  We must only do this once; hence it is in setUpClass
-        # rather than in setUp.
-        real_eventlet_sleep = eventlet.sleep
-        t_zmq.eventlet.sleep = simulated_time_sleep
+        # Hook sleeping.
+        self.real_eventlet_sleep = eventlet.sleep
+        eventlet.sleep = simulated_time_sleep
 
         # Similarly hook spawning.
-        real_eventlet_spawn = eventlet.spawn
-        t_zmq.eventlet.spawn = simulated_spawn
+        self.real_eventlet_spawn = eventlet.spawn
+        eventlet.spawn = simulated_spawn
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDownEventlet(self):
 
-        # Restore the real eventlet.sleep.
-        t_zmq.eventlet.sleep = real_eventlet_sleep
+        # Restore the real eventlet.sleep and eventlet.spawn.
+        eventlet.sleep = self.real_eventlet_sleep
+        eventlet.spawn = self.real_eventlet_spawn
 
     # Setup for explicit test code control of all operations on 0MQ sockets.
     def setUp_sockets(self):
@@ -189,14 +184,14 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         def make_poll(socket):
 
             def poll(ms):
-                print "T=%s: Socket %s poll for %sms..." % (current_time,
+                print "T=%s: Socket %s poll for %sms..." % (self.current_time,
                                                             socket,
                                                             ms)
 
                 # Add this socket's receive queue to the set of current
                 # sleepers.
                 socket.rcv_queue.stack = inspect.stack()[1][3]
-                sleepers[socket.rcv_queue] = current_time + ms / 1000
+                self.sleepers[socket.rcv_queue] = self.current_time + ms / 1000
 
                 # Block until there's something added to the queue.
                 msg = socket.rcv_queue.get(True)
@@ -204,13 +199,13 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                 # If what was added was not the timeout indication, put it back
                 # on the queue, for a following receive call.
                 if msg is not TIMEOUT_VALUE:
-                    del sleepers[socket.rcv_queue]
+                    del self.sleepers[socket.rcv_queue]
                     print "Requeue: %s" % msg
                     socket.rcv_queue.put_nowait(msg)
                 else:
                     print "Poll timed out"
 
-                real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+                self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
                 # Return nothing.
                 return None
@@ -228,72 +223,66 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
     # the code under test) without actually having to wait for that time.
     def setUp_time(self):
 
-        global current_time
-        global sleepers
-        global threads
-
         # Reset the simulated time (in seconds) that has passed since the
         # beginning of the test.
-        current_time = 0
+        self.current_time = 0
 
         # Make time.time() return current_time.
-        lib.m_time.time.side_effect = lambda: current_time
+        lib.m_time.time.side_effect = lambda: self.current_time
 
         # Reset the dict of current sleepers.  In each dict entry, the key is
         # an eventlet.Queue object and the value is the time at which the sleep
         # should complete.
-        sleepers = {}
+        self.sleepers = {}
 
-        threads = []
+        self.threads = []
 
     # Method for the test code to call when it wants to advance the simulated
     # time.
     def simulated_time_advance(self, secs):
 
-        global current_time
-
         while (secs > 0):
-            print "T=%s: Want to advance by %s" % (current_time, secs)
+            print "T=%s: Want to advance by %s" % (self.current_time, secs)
 
             # Determine the time to advance to in this iteration: either the
             # full time that we've been asked for, or the time at which the
             # next sleeper should wake up, whichever of those is earlier.
-            wake_up_time = current_time + secs
-            for queue in sleepers.keys():
-                if sleepers[queue] < wake_up_time:
+            wake_up_time = self.current_time + secs
+            for queue in self.sleepers.keys():
+                if self.sleepers[queue] < wake_up_time:
                     # This sleeper will wake up before the time that we've been
                     # asked to advance to.
-                    wake_up_time = sleepers[queue]
+                    wake_up_time = self.sleepers[queue]
 
             # Check if we're about to advance past any exact multiples of
             # HEARTBEAT_SEND_INTERVAL_SECS.
             num_acl_pub_heartbeats = (
                 int(wake_up_time / t_zmq.HEARTBEAT_SEND_INTERVAL_SECS) -
-                int(current_time / t_zmq.HEARTBEAT_SEND_INTERVAL_SECS)
+                int(self.current_time / t_zmq.HEARTBEAT_SEND_INTERVAL_SECS)
             )
 
             # Advance to the determined time.
-            secs -= (wake_up_time - current_time)
-            current_time = wake_up_time
-            print "T=%s" % current_time
+            secs -= (wake_up_time - self.current_time)
+            self.current_time = wake_up_time
+            print "T=%s" % self.current_time
 
             # Wake up all sleepers that should now wake up.
-            for queue in sleepers.keys():
-                if sleepers[queue] <= current_time:
-                    print "T=%s >= %s: %s: Wake up!" % (current_time,
-                                                        sleepers[queue],
+            for queue in self.sleepers.keys():
+                if self.sleepers[queue] <= self.current_time:
+                    print "T=%s >= %s: %s: Wake up!" % (self.current_time,
+                                                        self.sleepers[queue],
                                                         queue.stack)
-                    del sleepers[queue]
+                    del self.sleepers[queue]
                     queue.put_nowait(TIMEOUT_VALUE)
 
             # Allow woken (and possibly other) threads to run.
-            real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+            self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
             # Handle any ACL HEARTBEAT publications.
             for i in range(num_acl_pub_heartbeats):
                 print "Handle ACL HEARTBEAT publication"
                 pub = {'type': 'HEARTBEAT',
-                       'issued': current_time * 1000}
+                       'issued': self.current_time * 1000}
                 self.acl_pub_socket.send_multipart.assert_called_once_with(
                     ['networkheartbeat'.encode('utf-8'),
                      json.dumps(pub).encode('utf-8')])
@@ -302,6 +291,9 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
     # Setup before each test case (= each method below whose name begins with
     # "test").
     def setUp(self):
+
+        # Setup to control eventlet spawning and sleeping.
+        self.setUpEventlet()
 
         # Normally do not provide bind_host config.
         lib.m_oslo.config.cfg.CONF.bind_host = None
@@ -320,8 +312,11 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
         print "\nClean up remaining green threads..."
 
-        for thread in threads:
+        for thread in self.threads:
             thread.kill()
+
+        # Stop controlling eventlet spawning and sleeping.
+        self.tearDownEventlet()
 
     # Check that a socket is now bound to a specified address and port, and
     # return that socket.
@@ -451,13 +446,13 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         # Send a RESYNCSTATE.
         resync = {'type': 'RESYNCSTATE',
                   'resync_id': 'resync#1',
-                  'issued': current_time * 1000,
+                  'issued': self.current_time * 1000,
                   'hostname': 'felix-host-1'}
         self.felix_router_socket.rcv_queue.put_nowait(
             ['felix-1',
              '',
              json.dumps(resync).encode('utf-8')])
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check DB got create_or_update_agent call.
         if KEEP_EXISTING_REQ_SOCK not in flags:
@@ -493,7 +488,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                        'addr': ip['ip_address'],
                        'gateway': '10.65.0.1'} for ip in port['fixed_ips']],
                  'endpoint_id': port['id'],
-                 'issued': current_time * 1000,
+                 'issued': self.current_time * 1000,
                  'interface_name': 'tap' + port['id'][:11],
                  'state': 'enabled'},
                 t_zmq.zmq.NOBLOCK
@@ -506,15 +501,15 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                  'rc': 'SUCCESS'})
 
             # Yield twice to allow that response to be processed.
-            real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
-            real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+            self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+            self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Send HEARTBEAT from Felix and check for response.
         self.felix_router_socket.rcv_queue.put_nowait(
             ['felix-1',
              '',
              json.dumps({'type': 'HEARTBEAT'}).encode('utf-8')])
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
         self.felix_router_socket.send_multipart.assert_called_once_with(
             ['felix-1',
              '',
@@ -531,7 +526,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
         # Need another yield here, apparently, to allow felix_heartbeat_thread
         # to start running.
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Receive HEARTBEAT to Felix from the plugin, and send response.
         self.simulated_time_advance(30)
@@ -551,8 +546,8 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         self.felix_endpoint_socket.rcv_queue.put_nowait(
             {'type': 'HEARTBEAT'})
         print "Provided HEARTBEAT response from Felix on %s" % self.felix_endpoint_socket
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check DB got create_or_update_agent call.
         self.db.create_or_update_agent.assert_called_once_with(
@@ -564,18 +559,18 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         self.db.create_or_update_agent.reset_mock()
 
         # Yield to allow anything pending on other threads to come out.
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
     # Test what happens when an ACL Manager connects to the Neutron driver.
     def acl_connect(self):
         # Simulate ACL Manager sending GETGROUPS request.
         getgroups = {'type': 'GETGROUPS',
-                     'issued': current_time * 1000}
+                     'issued': self.current_time * 1000}
         self.acl_get_socket.rcv_queue.put_nowait(
             ['aclm-1',
              '',
              json.dumps(getgroups).encode('utf-8')])
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check get GETGROUPS response.
         self.acl_get_socket.send_multipart.assert_called_once_with(
@@ -606,7 +601,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                    'group': 'SGID-default',
                    'type': 'GROUPUPDATE',
                    'members': {},
-                   'issued': current_time * 1000}
+                   'issued': self.current_time * 1000}
         self.check_acl_pub('groups', gupdate)
 
         # Send HEARTBEAT from ACL Manager and check for response.
@@ -614,7 +609,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
             ['aclm-1',
              '',
              json.dumps({'type': 'HEARTBEAT'}).encode('utf-8')])
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
         self.acl_get_socket.send_multipart.assert_called_once_with(
             ['aclm-1',
              '',
@@ -661,17 +656,17 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         if NO_ENDPOINT_RESPONSE in flags:
             # Expect create_port_postcommit to throw a FelixUnavailable
             # exception.
-            real_eventlet_spawn(
+            self.real_eventlet_spawn(
                 lambda: self.assertRaises(t_zmq.FelixUnavailable,
                                           self.driver.create_port_postcommit,
                                           (context)))
         else:
             # No exception expected.
-            real_eventlet_spawn(
+            self.real_eventlet_spawn(
                 lambda: self.driver.create_port_postcommit(context))
 
         # Yield to allow that new thread to run.
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check ENDPOINTCREATED request is sent to Felix.  Simulate Felix
         # responding successfully.
@@ -682,7 +677,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                    'addr': ip['ip_address'],
                    'gateway': '10.65.0.1'} for ip in port['fixed_ips']],
              'endpoint_id': port['id'],
-             'issued': current_time * 1000,
+             'issued': self.current_time * 1000,
              'interface_name': 'tap' + port['id'][:11],
              'resync_id': None,
              'type': 'ENDPOINTCREATED',
@@ -702,8 +697,8 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
             {'type': 'ENDPOINTCREATED',
              'rc': 'SUCCESS',
              'message': ''})
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check get update_port_status call, indicating port active.
         self.db.update_port_status.assert_called_once_with(
@@ -737,7 +732,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                'members': {
                    port['id']: [ip['ip_address'] for ip in port['fixed_ips']]
                },
-               'issued': current_time * 1000}
+               'issued': self.current_time * 1000}
         self.check_acl_pub('groups', pub)
 
         # Exercise the notifier's general attribute proxying.
@@ -779,17 +774,17 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         if NO_ENDPOINT_RESPONSE in flags:
             # Expect update_port_postcommit to throw a FelixUnavailable
             # exception.
-            real_eventlet_spawn(
+            self.real_eventlet_spawn(
                 lambda: self.assertRaises(t_zmq.FelixUnavailable,
                                           self.driver.update_port_postcommit,
                                           (context)))
         else:
             # No exception expected.
-            real_eventlet_spawn(
+            self.real_eventlet_spawn(
                 lambda: self.driver.update_port_postcommit(context))
 
         # Yield to allow that new thread to run.
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check ENDPOINTUPDATED request is sent to Felix.  Simulate Felix
         # responding successfully.
@@ -799,7 +794,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                         'addr': '10.65.0.22',
                         'gateway': '10.65.0.1'}],
              'endpoint_id': lib.port1['id'],
-             'issued': current_time * 1000,
+             'issued': self.current_time * 1000,
              'type': 'ENDPOINTUPDATED',
              'state': 'enabled'},
             t_zmq.zmq.NOBLOCK)
@@ -817,8 +812,8 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
             {'type': 'ENDPOINTUPDATED',
              'rc': 'SUCCESS',
              'message': ''})
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
     # Test a rule being updated in a security group.
     def sg_rule_update(self):
@@ -854,7 +849,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                'group': 'SG-1',
                'type': 'GROUPUPDATE',
                'members': {},
-               'issued': current_time * 1000}
+               'issued': self.current_time * 1000}
         self.check_acl_pub('groups', pub)
 
     # Delete an endpoint.
@@ -872,23 +867,23 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         if NO_ENDPOINT_RESPONSE in flags:
             # Expect update_port_postcommit to throw a FelixUnavailable
             # exception.
-            real_eventlet_spawn(
+            self.real_eventlet_spawn(
                 lambda: self.assertRaises(t_zmq.FelixUnavailable,
                                           self.driver.delete_port_postcommit,
                                           (context)))
         else:
             # No exception expected.
-            real_eventlet_spawn(
+            self.real_eventlet_spawn(
                 lambda: self.driver.delete_port_postcommit(context))
 
         # Yield to allow that new thread to run.
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Check ENDPOINTDESTROYED request is sent to Felix.  Simulate Felix
         # responding successfully.
         self.felix_endpoint_socket.send_json.assert_called_once_with(
             {'endpoint_id': lib.port1['id'],
-             'issued': current_time * 1000,
+             'issued': self.current_time * 1000,
              'type': 'ENDPOINTDESTROYED'},
             t_zmq.zmq.NOBLOCK)
         self.felix_endpoint_socket.send_json.reset_mock()
@@ -905,8 +900,8 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
             {'type': 'ENDPOINTDESTROYED',
              'rc': 'SUCCESS',
              'message': ''})
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
-        real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
+        self.real_eventlet_sleep(REAL_EVENTLET_SLEEP_TIME)
 
         # Prep appropriate responses for next get_security_group and
         # _get_port_security_group_bindings calls.
@@ -928,7 +923,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
                'group': 'SG-1',
                'type': 'GROUPUPDATE',
                'members': {},
-               'issued': current_time * 1000}
+               'issued': self.current_time * 1000}
         self.check_acl_pub('groups', pub)
 
     def test_timing_new_endpoint(self):

--- a/calico/openstack/test/test_plugin_zmq.py
+++ b/calico/openstack/test/test_plugin_zmq.py
@@ -555,11 +555,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         self.give_way()
 
         # Check get update_port_status call, indicating port active.
-        self.db.update_port_status.assert_called_once_with(
-            context._plugin_context,
-            context._port['id'],
-            mech_calico.constants.PORT_STATUS_ACTIVE)
-        self.db.update_port_status.reset_mock()
+        self.check_update_port_status_called(context)
 
         # Prep appropriate responses for next get_security_group,
         # _get_port_security_group_bindings and get_port calls.

--- a/calico/openstack/test/test_plugin_zmq.py
+++ b/calico/openstack/test/test_plugin_zmq.py
@@ -30,12 +30,6 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
-if 'zmq' in sys.modules:
-    del sys.modules['zmq']
-sys.modules['oslo'] = m_oslo = mock.Mock()
-sys.modules['oslo.config'] = m_oslo.config
-sys.modules['time'] = m_time = mock.Mock()
-
 import calico.openstack.test.lib as lib
 import calico.openstack.mech_calico as mech_calico
 import calico.openstack.t_zmq as t_zmq
@@ -243,7 +237,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         current_time = 0
 
         # Make time.time() return current_time.
-        m_time.time.side_effect = lambda: current_time
+        lib.m_time.time.side_effect = lambda: current_time
 
         # Reset the dict of current sleepers.  In each dict entry, the key is
         # an eventlet.Queue object and the value is the time at which the sleep
@@ -310,7 +304,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
     def setUp(self):
 
         # Normally do not provide bind_host config.
-        m_oslo.config.cfg.CONF.bind_host = None
+        lib.m_oslo.config.cfg.CONF.bind_host = None
 
         # Setup to control 0MQ socket operations.
         self.setUp_sockets()
@@ -320,10 +314,6 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
         # Do common plugin test setup.
         super(TestPlugin0MQ, self).setUp()
-
-        # Use 0MQ transport.
-        self.driver.transport = t_zmq.CalicoTransport0MQ(self.driver,
-                                                         mech_calico.LOG)
 
     # Tear down after each test case.
     def tearDown(self):
@@ -347,7 +337,7 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
         # Provide bind_host config.
         ip_addr = '192.168.1.1'
-        m_oslo.config.cfg.CONF.bind_host = ip_addr
+        lib.m_oslo.config.cfg.CONF.bind_host = ip_addr
 
         # Tell the driver to initialize.
         self.driver.initialize()

--- a/calico/openstack/test/test_plugin_zmq.py
+++ b/calico/openstack/test/test_plugin_zmq.py
@@ -365,8 +365,6 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
     # "test").
     def setUp(self):
 
-        self.maxDiff = 1000
-
         # Normally do not provide bind_host config.
         m_oslo.config.cfg.CONF.bind_host = None
 
@@ -379,8 +377,8 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
         # Setup to control the passage of time.
         self.setUp_time()
 
-        # Create an instance of CalicoMechanismDriver.
-        self.driver = mech_calico.CalicoMechanismDriver()
+        # Do common plugin test setup.
+        super(TestPlugin0MQ, self).setUp()
 
         # Use 0MQ transport.
         self.driver.transport = t_zmq.CalicoTransport0MQ(self.driver,
@@ -516,11 +514,6 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
     def felix_connect(self, **kwargs):
 
-        # Hook the Neutron database.
-        self.db = mech_calico.manager.NeutronManager.get_plugin()
-        self.db_context = mech_calico.ctx.get_admin_context()
-        self.db.get_ports.return_value = self.osdb_ports
-
         # Get test variation flags.
         flags = kwargs.get('flags', set())
 
@@ -644,42 +637,6 @@ class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
     # Test what happens when an ACL Manager connects to the Neutron driver.
     def acl_connect(self):
-        # Prep response to next get_security_groups query, returning the
-        # default SG.  Prep a null response to the following
-        # _get_port_security_group_bindings call.
-        self.db = mech_calico.manager.NeutronManager.get_plugin()
-        self.db_context = mech_calico.ctx.get_admin_context()
-        self.db.get_security_groups.return_value = [
-            {'id': 'SGID-default',
-             'security_group_rules': [
-                 {'remote_group_id': 'SGID-default',
-                  'remote_ip_prefix': None,
-                  'protocol': -1,
-                  'direction': 'ingress',
-                  'ethertype': 'IPv4',
-                  'port_range_min': -1},
-                 {'remote_group_id': 'SGID-default',
-                  'remote_ip_prefix': None,
-                  'protocol': -1,
-                  'direction': 'ingress',
-                  'ethertype': 'IPv6',
-                  'port_range_min': -1},
-                 {'remote_group_id': None,
-                  'remote_ip_prefix': None,
-                  'protocol': -1,
-                  'direction': 'egress',
-                  'ethertype': 'IPv4',
-                  'port_range_min': -1},
-                 {'remote_group_id': None,
-                  'remote_ip_prefix': None,
-                  'protocol': -1,
-                  'direction': 'egress',
-                  'ethertype': 'IPv6',
-                  'port_range_min': -1}
-             ]}
-        ]
-        self.db._get_port_security_group_bindings.return_value = []
-
         # Simulate ACL Manager sending GETGROUPS request.
         getgroups = {'type': 'GETGROUPS',
                      'issued': current_time * 1000}

--- a/calico/openstack/test/test_plugin_zmq.py
+++ b/calico/openstack/test/test_plugin_zmq.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-openstack.test.test_plugin
+openstack.test.test_plugin_zmq
 ~~~~~~~~~~~
 
-Unit test for the Calico/OpenStack Plugin.
+Unit test for the Calico/OpenStack Plugin using 0MQ transport.
 """
 import mock
 import sys
@@ -34,30 +34,11 @@ else:
 
 if 'zmq' in sys.modules:
     del sys.modules['zmq']
-sys.modules['neutron'] = m_neutron = mock.Mock()
-sys.modules['neutron.common'] = m_neutron.common
-sys.modules['neutron.openstack'] = m_neutron.openstack
-sys.modules['neutron.openstack.common'] = m_neutron.openstack.common
-sys.modules['neutron.plugins'] = m_neutron.plugins
-sys.modules['neutron.plugins.ml2'] = m_neutron.plugins.ml2
-sys.modules['neutron.plugins.ml2.drivers'] = m_neutron.plugins.ml2.drivers
 sys.modules['oslo'] = m_oslo = mock.Mock()
 sys.modules['oslo.config'] = m_oslo.config
 sys.modules['time'] = m_time = mock.Mock()
-sys.modules['etcd'] = m_etcd = mock.Mock()
 
-
-# Define a stub class, that we will use as the base class for
-# CalicoMechanismDriver.
-class DriverBase(object):
-    def __init__(self, agent_type, vif_type, vif_details):
-        pass
-
-# Replace Neutron's SimpleAgentMechanismDriverBase - which is the base class
-# that CalicoMechanismDriver inherits from - with this stub class.
-m_neutron.plugins.ml2.drivers.mech_agent.SimpleAgentMechanismDriverBase = \
-    DriverBase
-
+import calico.openstack.test.lib as lib
 import calico.openstack.mech_calico as mech_calico
 import calico.openstack.t_zmq as t_zmq
 
@@ -90,7 +71,7 @@ port2 = {'binding:vif_type': 'tap',
          'admin_state_up': True}
 
 
-class TestPlugin(unittest.TestCase):
+class TestPlugin0MQ(lib.Lib, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -150,10 +131,6 @@ class TestPlugin(unittest.TestCase):
 
         # Restore the real eventlet.sleep.
         t_zmq.eventlet.sleep = real_eventlet_sleep
-
-    # Ports to return when the driver asks the OpenStack database for all
-    # current ports.
-    osdb_ports = []
 
     # Setup for explicit test code control of all operations on 0MQ sockets.
     def setUp_sockets(self):


### PR DESCRIPTION
There's still some more UT to do here, but I think it's worth getting review eyes on this and possibly banking it in the master branch.

Note that:
- this PR still leaves 0MQ as the default transport - because that's what we still want in master
- enhanced UT covers both the 0MQ and etcd transports, as well as the common part of the plugin code
- the UT passes.