### PR TITLE
Neutron mechanism driver: always get Neutron DB handle before using it in theoretical start-of-day window

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -132,10 +132,10 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         port = context._port
         if self._port_is_endpoint_port(port):
             LOG.info("Created port: %s" % port)
+            self._get_db()
             self.add_port_gateways(port, context._plugin_context)
             self.add_port_interface_name(port)
             self.transport.endpoint_created(port)
-            self._get_db()
             self.db.update_port_status(context._plugin_context,
                                        port['id'],
                                        constants.PORT_STATUS_ACTIVE)


### PR DESCRIPTION
add_port_gateways() requires self.db to have been set up, but potentially _get_db() hasn't been called yet.

This window was observed using a dummy Neutron for testing - it could only be hit in a live deployment if create_port_postcommit() can be called before any Felixes have connected - I'm not sure if this is possible.