### PR TITLE
Small typo and formatting fixes for docs

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -68,8 +68,8 @@ state. All of our components can be shutdown and restarted without risk,
 because they resynchronize state as necessary. This makes modelling
 their behaviour extremely simple, reducing the complexity of bugs.
 
-How Does Calico Interact with the Neutron API?
-----------------------------------------------
+"How Does Calico Interact with the Neutron API?"
+------------------------------------------------
 
 The :doc:`calico-neutron-api` document goes into extensive detail about how
 various Neutron API calls translate into Calico actions.

--- a/docs/source/fuel-integration.rst
+++ b/docs/source/fuel-integration.rst
@@ -183,9 +183,9 @@ With Calico networking, in addition:
 - BGP sessions are established, between BIRD instances on the compute
   nodes and on the route reflector, using these management IP
   addresses
-- data between VMs on different compute nodes is routed using these
+- Data between VMs on different compute nodes is routed using these
   management IP addresses, which means that it flows via the compute
-  nodes' =eth0= interfaces.
+  nodes' ``eth0`` interfaces.
 
 Storage
 ~~~~~~~
@@ -222,8 +222,8 @@ simplify the web UI for Calico networking.
 Configure BGP route reflector on the controller
 -----------------------------------------------
 
-Once the deployment is complete - and also, if you later add more
-compute nodes to the deployment - you need to update the BGP route
+Once the deployment is complete -- and also, if you later add more
+compute nodes to the deployment -- you need to update the BGP route
 reflector configuration on the controller node.
 
 To do this, log onto the controller node and run::
@@ -255,8 +255,8 @@ Also in the OpenStack web UI, under Admin, System Info, Network
 Agents, verify that there is an instance of 'Felix (Calico agent)'
 running on each compute node, and that its Status is Up.
 
-Under Project, Instances, launch a batch of VMs - enough of them to
-ensure that there will be at least one VM on each compute node - with
+Under Project, Instances, launch a batch of VMs -- enough of them to
+ensure that there will be at least one VM on each compute node -- with
 the following details.
 
 - Flavor: m1.tiny
@@ -290,7 +290,7 @@ Detailed Observations
 
 This section records some more detailed notes about the state of the
 cluster that results from following the above procedure with HEAD
-commit 854d2353 from https://github.com/Metaswitch/fuel-library.
+commit 854d2353 from `our fork of the Fuel library <https://github.com/Metaswitch/fuel-library>`__.
 Reading this section should not be required in order to demonstrate or
 understand Openstack and Calico function, but it may be useful as a reference
 if a newly deployed system does not appear to be behaving correctly.

--- a/docs/source/fuel-integration.rst
+++ b/docs/source/fuel-integration.rst
@@ -290,7 +290,8 @@ Detailed Observations
 
 This section records some more detailed notes about the state of the
 cluster that results from following the above procedure with HEAD
-commit 854d2353 from `our fork of the Fuel library <https://github.com/Metaswitch/fuel-library>`__.
+commit 854d2353 from `our fork of the Fuel library
+<https://github.com/Metaswitch/fuel-library>`__.
 Reading this section should not be required in order to demonstrate or
 understand Openstack and Calico function, but it may be useful as a reference
 if a newly deployed system does not appear to be behaving correctly.

--- a/docs/source/l3-interconnectFabric.rst
+++ b/docs/source/l3-interconnectFabric.rst
@@ -88,7 +88,7 @@ technical note.
 
 #. The routing infrastructure is based on some form of IGP. Due to the
    limitations in scale of IGP networks (see the `why
-   bgp post <http://www.projectcalico.org/why-bgp/>`__ for discussion of
+   BGP post <http://www.projectcalico.org/why-bgp/>`__ for discussion of
    this topic.  The project Calico team does not believe that using an
    IGP to distribute end--point reachability information will
    adequitely scale in a Calico environment.  However, it is possible

--- a/docs/source/opens-chef-install.rst
+++ b/docs/source/opens-chef-install.rst
@@ -61,6 +61,7 @@ starting the bootstrap process:
       and set the correct name for each node (names must be unique).
    -  Ensure your loopback IP and OpenStack DNS entries are configured. Edit
       the ``/etc/hosts`` file:
+      
       -  Set the loopback IP address to 127.0.0.1.
       -  Set your hostname IP address to your static IP.
    -  Configure the hostnames / IPs of the other OpenStack nodes.

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -277,10 +277,10 @@ On a compute node, perform the following steps:
         yum install calico-compute
 
 11. Configure BIRD. Calico includes useful configuration scripts that
-    will create BIRD config files for simple topologies - either a
+    will create BIRD config files for simple topologies -- either a
     peering between a single pair of compute nodes, or to a route
     reflector (to avoid the need for a full BGP mesh in networks with
-    more than 2 compute nodes). If your topology is more complex, please
+    more than two compute nodes). If your topology is more complex, please
     consult the relevant documentation for your chosen BGP stack or ask
     the mailing list if you have questions about how BGP relates to
     Calico.
@@ -297,8 +297,8 @@ On a compute node, perform the following steps:
 
         /usr/bin/calico-gen-bird6-conf.sh <compute_node_ipv4> <compute_node_ipv6> <peer_ipv6> <bgp_as_number>
 
-    ``<compute_node_ipv4>`` and \`' are the IPv4/6 addresses of the
-    compute host, used as next hops and router ids.
+    ``<compute_node_ipv4>`` and ``<compute_node_ipv6>`` are the IPv4/6
+    addresses of the compute host, used as next hops and router ids.
 
     ``<peer_ipv4>`` and ``<peer_ipv6>`` are the IP address of your
     single other compute node, or the route reflector as described
@@ -309,7 +309,7 @@ On a compute node, perform the following steps:
     Unless your deployment needs to peer with other BGP routers, this
     can be chosen arbitrarily.
 
-    For RHEL 6.5, ignore any ``bird: unrecognized service`` error - we'll
+    For RHEL 6.5, ignore any ``bird: unrecognized service`` error -- we'll
     restart BIRD later anyway.
 
    Note that you'll also need to configure your route reflector to allow
@@ -320,18 +320,18 @@ On a compute node, perform the following steps:
 
    - For RHEL 7:
 
-   ::
+     ::
 
-       service bird restart
-       service bird6 restart
-       chkconfig bird on
-       chkconfig bird6 on
+         service bird restart
+         service bird6 restart
+         chkconfig bird on
+         chkconfig bird6 on
 
    - For RHEL 6.5:
 
-   ::
+     ::
 
-       initctl start bird
+         initctl start bird
 
 12. Create the ``/etc/calico/felix.cfg`` file by copying
     ``/etc/calico/felix.cfg.example`` and edit it:
@@ -340,8 +340,8 @@ On a compute node, perform the following steps:
        host name or IP address of the controller node.
     -  Restart the Felix service:
 
-       - on Red Hat 6.5, run ``initctl start calico-felix``.
-       - on Red Hat 7, run ``systemctl restart calico-felix``.
+       - on RHEL 6.5, run ``initctl start calico-felix``.
+       - on RHEL 7, run ``systemctl restart calico-felix``.
 
 Next Steps
 ----------

--- a/docs/source/ubuntu-opens-install.rst
+++ b/docs/source/ubuntu-opens-install.rst
@@ -278,9 +278,9 @@ On a compute node, perform the following steps:
 
        calico-gen-bird-conf.sh <compute_node_ip> <route_reflector_ip> <bgp_as_number>
 
-And/or for IPv6 connectivity between compute hosts:
+   And/or for IPv6 connectivity between compute hosts:
 
-::
+   ::
 
         calico-gen-bird6-conf.sh <compute_node_ipv4> <compute_node_ipv6> <route_reflector_ipv6> <bgp_as_number>
 


### PR DESCRIPTION
List of changes:

* Add quotes around the title of the final question on the FAQs page to bring
  it in line with the style of the other titles on the page.
* Fix formatting of `eth0` in `fuel-integration.rst`.
* Fix list formatting in `opens-chef-install.rst`.
* Add missing text to `redhat-opens-install.rst`.
* Fix indentation in `redhat-opens-install.rst`.
* Fix indentation in `ubuntu-opens-install.rst`.
* Tidy up a couple of links.
* Replace hyphens with en dashes in a few places.

I tested all of these changes with a local build of the HTML docs.