### PR TITLE
Fix small spelling, capitalization and hyphenization mistakes in docs

### DIFF
--- a/docs/source/api-proposal.rst
+++ b/docs/source/api-proposal.rst
@@ -265,7 +265,7 @@ Request: ENDPOINTCREATED
       messages that are triggered by such a request from other
       ENDPOINTCREATED messages. Should be ``null`` if this message is
       not triggered by a "RESYNCSTATE" message.
-   -  *issued*: A unix timestamp with millisecond or better precision
+   -  *issued*: A Unix timestamp with millisecond or better precision
       corresponding to the time the request was issued.
 
 This request is an indication that the plugin or orchestrator has
@@ -275,7 +275,7 @@ all systems to carry data about an endpoint if Felix has requested state
 resynchronisation (see the "RESYNCSTATE" message below).
 
 When state resynchronisation is in progress, no ``ENDPOINTCREATED``
-messages for new endpoint creation (i.e. with *resnyc\_id* equal to
+messages for new endpoint creation (i.e. with *resync\_id* equal to
 ``null``) can be sent until the state resynchronisation has completed.
 
 Response: ENDPOINTCREATED
@@ -325,7 +325,7 @@ Request: ENDPOINTUPDATED
       values, "enabled" and "disabled". A endpoint that is "enabled" is
       reachable on its virtual network: an endpoint that is "disabled"
       is not.
-   -  *issued*: A unix timestamp with millisecond or better precision
+   -  *issued*: A Unix timestamp with millisecond or better precision
       corresponding to the time the request was issued.
 
 This request asks Felix to update the state of a given endpoint. Any of
@@ -360,7 +360,7 @@ Request: ENDPOINTDESTROYED
 
    -  *endpoint\_id*: The UUID4 uniquely identifying the endpoint to
       destroy.
-   -  *issued*: A unix timestamp with millisecond or better precision
+   -  *issued*: A Unix timestamp with millisecond or better precision
       corresponding to the time the request was issued.
 
 This request asks Felix to destroy an endpoint. It instructs Felix to
@@ -393,10 +393,10 @@ Request: RESYNCSTATE
    its body:
 
    -  *resync\_id*: A unique string identifier for this state
-      resychronisation request. This identifier will be included on all
+      resynchronization request. This identifier will be included on all
       the triggered ``ENDPOINTCREATED`` messages, and can be used to
       identify them.
-   -  *issued*: A unix timestamp with millisecond or better precision
+   -  *issued*: A Unix timestamp with millisecond or better precision
       corresponding to the time the request was issued.
    -  *hostname*: The hostname of the Felix issuing the request.
 
@@ -596,7 +596,7 @@ Request: GETACLSTATE
 
 -  **Type**: ``GETACLSTATE``
 -  **Direction**: Felix → ACL Manager
--  **Body**: A ``GETACLSTATE`` request contains the fillowing fields in
+-  **Body**: A ``GETACLSTATE`` request contains the following fields in
    its body:
 
    -  *endpoint\_id*: The UUID4 representing the endpoint whose ACLs
@@ -653,7 +653,7 @@ Publication: HEARTBEAT
       indicating when the heartbeat was issued.
 
 Each Calico network has a single ``aclheartbeat`` subscription running
-between the ACL manager and all the Felices. This subscription never has
+between the ACL manager and all the Felixes. This subscription never has
 ACLs published on it. Instead, every 30 seconds the ACL manager
 publishes a single heartbeat message.
 
@@ -857,7 +857,7 @@ changed, and contains the entire rules state for that security group,
 including the rules and memberships.
 
 This message is also issued to notify the ACL manager about new security
-groups, and to inform it of whem a security group has been removed. New
+groups, and to inform it of when a security group has been removed. New
 security groups are notified simply by sending a notification of their
 rules and members. The removal of a security group is notified by
 sending a ``GROUPUPDATE`` for the group with an empty *members* object.
@@ -935,7 +935,7 @@ object with the following keys:
    specific security group. If the *cidr* key is present, this key MUST
    be ``null``.
 -  *cidr*: This rule allows/denies connections coming to/from a specific
-   subnet. If the *group* key is present, ths key MUST be ``null``.
+   subnet. If the *group* key is present, this key MUST be ``null``.
 -  *protocol*: The network protocol (e.g. "udp"). To match all
    protocols, send ``null``.
 -  *port*: This rule only affects traffic to/from this port. Should be a

--- a/docs/source/calico-neutron-api.rst
+++ b/docs/source/calico-neutron-api.rst
@@ -89,7 +89,7 @@ All properties on a port work as normal, except for the following:
   The network ID still controls which Neutron network the port is attached to,
   and therefore still controls which Neutron subnets it will be placed in.
   However, as per the note in :ref:`neutron-api-networks`, the Neutron network
-  that a port is placed in does not affect which machines in the deplyoment it
+  that a port is placed in does not affect which machines in the deployment it
   can contact.
 
 Extended Attributes: Port Binding Attributes

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -14,13 +14,13 @@ solving this problem have problems at high scale.  Compared to these, we think
 Calico is more scalable, simpler and more flexible.  We think you should look
 into it if you have more than a handful of nodes on a single site.
 
-For a more detailed discussion of this topic, see our blog post at 
-http://www.projectcalico.org/why-calico/.
+For a more detailed discussion of this topic, see our blog post at
+`Why Calico? <http://www.projectcalico.org/why-calico/>`__.
 
 "Does Calico work with IPv6?"
 -----------------------------
 
-Yes!  We have demonstrated IPv6 with Calico on Openstack and Docker/Powerstrip.
+Yes!  We have demonstrated IPv6 with Calico on OpenStack and Docker/Powerstrip.
 
 "Is Calico compliant with PCI/DSS requirements?"
 ------------------------------------------------

--- a/docs/source/fuel-integration.rst
+++ b/docs/source/fuel-integration.rst
@@ -293,7 +293,7 @@ cluster that results from following the above procedure with HEAD
 commit 854d2353 from `our fork of the Fuel library
 <https://github.com/Metaswitch/fuel-library>`__.
 Reading this section should not be required in order to demonstrate or
-understand Openstack and Calico function, but it may be useful as a reference
+understand OpenStack and Calico function, but it may be useful as a reference
 if a newly deployed system does not appear to be behaving correctly.
 
 Elements required for Calico function

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Calico is an open source solution for virtual networking in
 cloud data centers, developed by `Metaswitch
 Networks <http://www.metaswitch.com/>`__ and released under the `Apache
 2.0
-License <https://github.com/Metaswitch/calico-docs/blob/master/LICENSE.txt>`__.
+License <https://github.com/Metaswitch/calico/blob/master/LICENSE>`__.
 You can find high level information about it on `our
 website <http://www.projectcalico.org/>`__, and more detailed documentation
 here.

--- a/docs/source/ipv6.rst
+++ b/docs/source/ipv6.rst
@@ -96,7 +96,7 @@ implemented in Calico.
      Proxy NDP to ensure that routes to all machines go via the compute host.
 
    - rather than using DHCPv6 to allocate IPv6 addresses, we allocate the IPv6
-     address directly to the container interface betfore we move it into the
+     address directly to the container interface before we move it into the
      container.
 
 -  BIRD6 runs between the compute hosts to distribute routes.

--- a/docs/source/l2-interconnectFabric.rst
+++ b/docs/source/l2-interconnectFabric.rst
@@ -18,12 +18,12 @@ This means that the standard tools used to transport IP, such as MPLS
 and Ethernet can be used in a Calico network.
 
 In this note, I'm going to focus on Ethernet as the interconnect
-network. Talking to most at--scale cloud operators, they have converted
+network. Talking to most at-scale cloud operators, they have converted
 to IP fabrics, and as will cover in the next blog post that
 infrastructure will work for Calico as well. However, the concerns that
 drove most of those operators to IP as the interconnection network in
 their pods are largely ameliorated by Project Calico, allowing Ethernet
-to be viably considered as a Calico interconnect, even in large--scale
+to be viably considered as a Calico interconnect, even in large-scale
 deployments.
 
 Concerns over Ethernet at scale
@@ -36,7 +36,7 @@ deployment. Although there have been
 `attempts <http://www.cisco.com/web/about/ac123/ac147/archived_issues/ipj_14-3/143_trill.html>`__
 `to
 address <http://en.wikipedia.org/wiki/Virtual_Private_LAN_Service>`__
-these issues, the scale--out networking community has, largely abandoned
+these issues, the scale-out networking community has, largely abandoned
 Ethernet for anything other than providing physical point-to-point links
 in the networking fabric. The principal reasons for Ethernet failures at
 large scale are:
@@ -50,7 +50,7 @@ large scale are:
 #. High rate of *churn* or change in the network. With that many end
    points, most of them being ephemeral (such as virtual machines or
    containers), there is a large amount of *churn* in the network. That
-   load of re--learning paths can be a substantial burden on the control
+   load of re-learning paths can be a substantial burden on the control
    plane processor of most Ethernet switches.
 
 #. High volumes of broadcast traffic. As each node on the Ethernet
@@ -90,7 +90,7 @@ Internet peering points, where large fractions of Internet traffic is
 exchanged. The switches only see the routers from the various ISPs, not
 those ISPs' customers' nodes. We leverage the same effect in Calico.
 
-To take the issues outlined above, let's re--visit them in a Calico
+To take the issues outlined above, let's revisit them in a Calico
 context.
 
 #. Large numbers of end points. In a Calico network, the Ethernet
@@ -124,7 +124,7 @@ context.
    Ethernet fabric, period. In fact, the only broadcast traffic that
    should be seen in the Ethernet fabric is the ARPs of the compute
    servers locating each other. If the traffic pattern is fairly
-   consistent, the steady--state ARP rate should be almost zero. Even in
+   consistent, the steady-state ARP rate should be almost zero. Even in
    a pathological case, the ARP rate should be well within normal
    accepted boundaries.
 
@@ -154,7 +154,7 @@ fabric topology become possible.
 We assume that an Ethernet fabric for Calico would most likely be
 constructed as a *leaf/spine* architecture. Other options are possible,
 but the *leaf/spine* is the predominant architectural model in use in
-scale--out infrastructure today.
+scale-out infrastructure today.
 
 Since Calico is an IP routed fabric, a Calico network can use
 `ECMP <http://en.wikipedia.org/wiki/Equal-cost_multi-path_routing>`__ to

--- a/docs/source/l3-interconnectFabric.rst
+++ b/docs/source/l3-interconnectFabric.rst
@@ -91,7 +91,7 @@ technical note.
    BGP post <http://www.projectcalico.org/why-bgp/>`__ for discussion of
    this topic.  The project Calico team does not believe that using an
    IGP to distribute end--point reachability information will
-   adequitely scale in a Calico environment.  However, it is possible
+   adequately scale in a Calico environment.  However, it is possible
    to use a combination of IGP and BGP in the interconnect fabric,
    where an IGP communicates the path to the *next--hop* router (in
    Calico, this is often the destination compute server) and BGP is
@@ -336,7 +336,7 @@ its ToR switch which is also acting as an eBGP router.  For two
 servers within the same rack to communicate, they will be routed
 through the ToR.  Therefore, each server will have one peering to each
 ToR it is connected to, and each ToR will have a peering with each
-compute serer that it is connected to (normally, all the compute
+compute server that it is connected to (normally, all the compute
 servers in the rack).
 
 The inter--ToR connectivity considerations are the same in scale and
@@ -363,7 +363,7 @@ The way the physical and logical connectivity is laid out in this
 note, and the `Ethernet fabric note`_, The next hop router for a given
 route is always directly connected to the router receiving that
 route.  This makes the need for another protocol to distribute the
-next hop routes unecessary.
+next hop routes unnecessary.
 
 .. _`Ethernet fabric note`:
    http://docs.projectcalico.org/en/latest/l2-interconnectFabric.html 

--- a/docs/source/worked-examples-openstack.rst
+++ b/docs/source/worked-examples-openstack.rst
@@ -32,7 +32,7 @@ Because the user wants to be able to reach the machine from their own laptop,
 they need the machine to be reachable from outside the data center. In
 vanilla Neutron, this would mean provisioning it with a floating IP, but in
 Calico they instead want to make sure the VM is attached to the ``external``
-network. To add themseves to this network, the user needs to find out the UUID
+network. To add themselves to this network, the user needs to find out the UUID
 for it:
 
 .. code-block:: bash


### PR DESCRIPTION
* Fix capitalization of "Unix" and "OpenStack".
* Change "Felices" to "Felixes" to be consistent with the rest of the
  docs.
* Improve link to "Why Calico" blog post in FAQs.
* Fix link to license to reflect the retirement of the calico-docs
  repo.
* Replace en dashes with hyphens where appropriate.
* Fix spelling errors.