### PR TITLE
Purge all mentions of the calico-docs repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ To get started, you first need a working installation of
 stable build of Calico following the instructions
 [here](http://www.projectcalico.org/download/).
 
-Technical documentation is
-[on ReadTheDocs](http://docs.projectcalico.org/);
+Technical documentation is [here](http://docs.projectcalico.org/);
 if you are going to contribute to the project, you'll also need to run the
 [tests](doc/CalicoUTs.md).
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ stable build of Calico following the instructions
 [here](http://www.projectcalico.org/download/).
 
 Technical documentation is
-[here](https://github.com/Metaswitch/calico-docs/wiki);
+[on ReadTheDocs](http://docs.projectcalico.org/);
 if you are going to contribute to the project, you'll also need to run the
 [tests](doc/CalicoUTs.md).
 
@@ -96,7 +96,7 @@ OpenStack plugin, you'll also need to install Neutron: doing that is outside
 the scope of this article.
 
 To run the unit tests, you'll also need to type:
-    
+
     pip install nose mock
 
 Then, still at the root of the calico directory, run:

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -20,8 +20,8 @@
 #
 # This module is the OpenStack-specific implementation of the Plugin component
 # of the new Calico architecture (described by the "Felix, the Calico Plugin
-# and the Calico ACL Manager" wiki page at
-# https://github.com/Metaswitch/calico-docs/wiki).
+# and the Calico ACL Manager" document at
+# http://docs.projectcalico.org/en/latest/arch-felix-and-acl.html).
 #
 # It is implemented as a Neutron/ML2 mechanism driver.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Calico is an open source solution for virtual networking in
 cloud data centers, developed by `Metaswitch
 Networks <http://www.metaswitch.com/>`__ and released under the `Apache
 2.0
-License <https://github.com/Metaswitch/calico-docs/blob/master/LICENSE.txt>`__.
+License <https://github.com/Metaswitch/calico/blob/master/LICENSE>`__.
 You can find high level information about it on `our
 website <http://www.projectcalico.org/>`__, and more detailed documentation
 here.

--- a/docs/source/ubuntu-opens-install.rst
+++ b/docs/source/ubuntu-opens-install.rst
@@ -304,6 +304,5 @@ On a compute node, perform the following steps:
 Next Steps
 ----------
 
-Now you've installed Calico, `this
-article <https://github.com/Metaswitch/calico-docs/wiki/Installation-Instructions#next-steps>`__
-details how to configure networks and use your new deployment.
+Now you've installed Calico, :doc:`next-steps` details how to configure
+networks and use your new deployment.


### PR DESCRIPTION
Per [pull request #4](https://github.com/Metaswitch/calico-docs/pull/4) on the calico-docs repo, this commit purges all mentions of the calico-docs repository from this repo.

A grep for the phrase “calico-docs” in my local copy now shows no mentions of the phrase except in the Debian and RPM changelogs announcing the move.