### PR TITLE
Whitelist ip_version as a valid rule attribute.

### DIFF
--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -48,6 +48,7 @@ KNOWN_RULE_KEYS = set([
     "dst_tag",
     "dst_ports",
     "icmp_type",
+    "ip_version",
 ])
 
 


### PR DESCRIPTION
Should fix #312.  @robbrockbank  is running a test...