### PR TITLE
Let environment override global config file for docker support.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -70,8 +70,8 @@ class Config(object):
 
         self.read_cfg_file(config_path)
 
-        self.ETCD_HOST = self.get_cfg_entry("global", "EtcdHost", "localhost")
-        self.ETCD_PORT = int(self.get_cfg_entry("global", "EtcdPort", "4001"))
+        self.ETCD_ADDR = self.get_cfg_entry("global", "EtcdAddr",
+                                            "localhost:4001")
 
         self.HOSTNAME = self.get_cfg_entry("global",
                                            "FelixHostname",
@@ -127,7 +127,10 @@ class Config(object):
         name = name.lower()
         section = section.lower()
 
-        env_var = ("%s_%s" % (section, name)).upper()
+        # We're assuming that there's only one section for now so we don't
+        # need the section name in the environment variable name.
+        assert section == "global"
+        env_var = ("FELIX_%s" % name).upper()
         log.debug("Looking for environment variable override %s", env_var)
         if env_var in os.environ:
             value = os.environ[env_var]

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -98,8 +98,14 @@ class EtcdWatcher(Actor):
 
     def _reconnect(self):
         _log.info("(Re)connecting to etcd...")
-        self.client = etcd.Client(self.config.ETCD_HOST,
-                                  self.config.ETCD_PORT)
+        etcd_addr = self.config.ETCD_ADDR
+        if ":" in etcd_addr:
+            host, port = etcd_addr.split(":")
+            port = int(port)
+        else:
+            host = etcd_addr
+            port = 4001
+        self.client = etcd.Client(host, port)
 
     @actor_event
     def watch_etcd(self):

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -98,7 +98,8 @@ class EtcdWatcher(Actor):
 
     def _reconnect(self):
         _log.info("(Re)connecting to etcd...")
-        self.client = etcd.Client('localhost', self.config.ETCD_PORT)
+        self.client = etcd.Client(self.config.ETCD_HOST,
+                                  self.config.ETCD_PORT)
 
     @actor_event
     def watch_etcd(self):

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -32,8 +32,6 @@ class TestConig(unittest.TestCase):
         """
         Test environment variables override config options,
         """
-        with patch.dict("os.environ", {"GLOBAL_ETCDHOST": "testhost",
-                                       "GLOBAL_ETCDPORT": "1234"}):
+        with patch.dict("os.environ", {"FELIX_ETCDADDR": "testhost:1234"}):
             cfg = config.Config("/tmp/felix.cfg")
-        self.assertEqual(cfg.ETCD_HOST, "testhost")
-        self.assertEqual(cfg.ETCD_PORT, 1234)
+        self.assertEqual(cfg.ETCD_ADDR, "testhost:1234")

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+felix.test.test_config
+~~~~~~~~~~~~~~~~~~~~~~
+
+Tests of the config module.
+"""
+import logging
+import unittest
+from mock import patch
+from calico.felix import config
+
+_log = logging.getLogger(__name__)
+
+
+class TestConig(unittest.TestCase):
+    @patch("ConfigParser.ConfigParser", autospec=True)
+    def test_env_var_override(self, m_ConfigParser):
+        """
+        Test environment variables override config options,
+        """
+        with patch.dict("os.environ", {"GLOBAL_ETCDHOST": "testhost",
+                                       "GLOBAL_ETCDPORT": "1234"}):
+            cfg = config.Config("/tmp/felix.cfg")
+        self.assertEqual(cfg.ETCD_HOST, "testhost")
+        self.assertEqual(cfg.ETCD_PORT, 1234)


### PR DESCRIPTION
- felix now allows GLOBAL_ETCDHOST and GLOBAL_ETCDPORT to be
  specified.
- fixes #326.