### PR TITLE
Rework startup to avoid concurrent access to config object

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -147,7 +147,7 @@ def default_logging():
     else:
         # Probably unit tests running on windows.
         syslog_handler = logging.handlers.SysLogHandler()
-    syslog_handler.setLevel(logging.DEBUG) # FIXME Temporarily log at DEBUG
+    syslog_handler.setLevel(logging.INFO)
     syslog_handler.setFormatter(syslog_formatter)
 
     root_logger.addHandler(syslog_handler)

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -42,7 +42,7 @@ class TestException(Exception):
 
 class TestBasic(BaseTestCase):
 
-    @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config_and_wait_for_ready")
+    @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config")
     @mock.patch("gevent.Greenlet.start", autospec=True)
     @mock.patch("calico.felix.felix.IptablesUpdater", autospec=True)
     @mock.patch("gevent.iwait", autospec=True, side_effect=TestException())


### PR DESCRIPTION
I've done the simplest thing; we no longer try to update the config on each pass around the resync loop.  I'm interested in @plwhite's opinion on whether we should kill felix if we do get a config update that we don't know how to handle (which is all but the Ready flag right now).

Due to conflicts between this and my pull req to handle etcd errors correctly, I've rebased this pull req on top of that one.