### PR TITLE
Workaround tox gevent install bug

### DIFF
--- a/run-unit-test.sh
+++ b/run-unit-test.sh
@@ -8,5 +8,5 @@
 set -e
 
 coverage erase
-tox "$@"
+PYTHONDONTWRITEBYTECODE=1 tox "$@"
 coverage html


### PR DESCRIPTION
Our Jenkins builds are failing with the following error.  This workaround should fix it.

`Command /var/lib/jenkins/workspace/unit-test/.tox/py27/bin/python2.7 -c "import setuptools, tokenize;__file__='/var/lib/jenkins/workspace/unit-test/.tox/py27/build/gevent/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-8oXIho-record/install-record.txt --single-version-externally-managed --compile --install-headers /var/lib/jenkins/workspace/unit-test/.tox/py27/include/site/python2.7 failed with error code 1 in /var/lib/jenkins/workspace/unit-test/.tox/py27/build/gevent
Traceback (most recent call last):
  File ".tox/py27/bin/pip", line 11, in <module>
    sys.exit(main())
  File "/var/lib/jenkins/workspace/unit-test/.tox/py27/local/lib/python2.7/site-packages/pip/__init__.py", line 185, in main
    return command.main(cmd_args)
  File "/var/lib/jenkins/workspace/unit-test/.tox/py27/local/lib/python2.7/site-packages/pip/basecommand.py", line 161, in main
    text = '\n'.join(complete_log)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 33: ordinal not in range(128)`