### PR TITLE
DO NOT MERGE: Use eternal_watch feature of our fork of python-etcd to:

### DIFF
--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,4 +1,4 @@
 gevent
 greenlet
 netaddr
-python-etcd
+calico-python-etcd

--- a/openstack_plugin_requirements.txt
+++ b/openstack_plugin_requirements.txt
@@ -1,3 +1,3 @@
 eventlet
 six
-python-etcd
+calico-python-etcd


### PR DESCRIPTION
- get cluster UUID checking
- do more efficient polling with fewer reconnects.