### PR TITLE
Reinstate modifiedIndex tracking

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -230,8 +230,11 @@ class EtcdWatcher(Actor):
                     gevent.sleep(1)
                     continue
 
-                # Keep it simple, just poll on the next possible index.
-                next_etcd_index += 1
+                # Since we're polling on a subtree, we can't just increment
+                # the index, we have to look at the modifiedIndex to spot if
+                # we've skipped a lot of updates.
+                next_etcd_index = max(next_etcd_index,
+                                      response.modifiedIndex) + 1
 
                 # TODO: regex parsing getting messy.
                 profile_id, rules = parse_if_rules(response)


### PR DESCRIPTION
Needed to avoid lots of spurious polling in Docker land.