### PR TITLE
Workaround for etcd polling issue

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -230,8 +230,11 @@ class EtcdWatcher(Actor):
                     gevent.sleep(1)
                     continue
 
-                # Keep it simple, just poll on the next possible index.
-                next_etcd_index += 1
+                # Since we're polling on a subtree, we can't just increment
+                # the index, we have to look at the modifiedIndex to spot if
+                # we've skipped a lot of updates.
+                next_etcd_index = max(next_etcd_index,
+                                      response.modifiedIndex) + 1
 
                 # TODO: regex parsing getting messy.
                 profile_id, rules = parse_if_rules(response)

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -200,6 +200,7 @@ class EtcdWatcher(Actor):
                     # This is expected when we're doing a poll and nothing
                     # happened.
                     _log.debug("Read from etcd timed out, retrying.")
+                    self._reconnect()
                     continue
                 except EtcdException as e:
                     # Sadly, python-etcd doesn't have a clean exception
@@ -228,6 +229,7 @@ class EtcdWatcher(Actor):
                         continue_polling = False
                     # TODO: should we do a backoff here?
                     gevent.sleep(1)
+                    self._reconnect()
                     continue
 
                 # Since we're polling on a subtree, we can't just increment


### PR DESCRIPTION
Trigger a full reconnect whenever we hit a timeout to avoid incorrect connection reuse.