### PR TITLE
Partial support for anycast, cleanup/comment ipsets code

### DIFF
--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -195,8 +195,8 @@ class IpsetManager(ReferenceManager):
             new_tags = set()
             new_prof_id = None
         else:
-            new_prof_id = endpoint.get["profile_id"]
-            new_tags = self.tags_by_prof_id.get(new_prof_id, set())
+            new_prof_id = endpoint.get("profile_id")
+            new_tags = set(self.tags_by_prof_id.get(new_prof_id, []))
 
         if new_prof_id != old_prof_id:
             self._remove_profile_index(old_prof_id, endpoint_id)

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -50,8 +50,11 @@ class IpsetManager(ReferenceManager):
         self.tags_by_prof_id = {}
         self.endpoints_by_ep_id = {}
 
-        # Indexes.
-        self.endpoint_ids_by_tag = defaultdict(set)
+        # Main index self.ip_owners_by_tag[tag][ip] == set([endpoint_id])
+        self.ip_owners_by_tag = defaultdict(lambda: defaultdict(set))
+        # And the actual ip memberships
+        self.ips_in_tag = defaultdict(set)
+
         self.endpoint_ids_by_profile_id = defaultdict(set)
 
     def _create(self, tag_id):
@@ -61,13 +64,7 @@ class IpsetManager(ReferenceManager):
         # if other messages are arriving.
         active_ipset = ActiveIpset(futils.uniquely_shorten(tag_id, 16),
                                    self.ip_type)
-
-        members = set()
-        for ep_id in self.endpoint_ids_by_tag.get(tag_id, set()):
-            ep = self.endpoints_by_ep_id.get(ep_id, {})
-            nets = self.nets_key
-            members.update(map(futils.net_to_ip, ep.get(nets, [])))
-
+        members = self.ips_in_tag.get(tag_id, set())
         active_ipset.replace_members(members, async=True)
         return active_ipset
 
@@ -153,6 +150,12 @@ class IpsetManager(ReferenceManager):
         else:
             self.tags_by_prof_id[profile_id] = tags
 
+    def _extract_ips(self, endpoint):
+        if endpoint is None:
+            return set()
+        return set(map(futils.net_to_ip,
+                       endpoint.get(self.nets_key, [])))
+
     def _process_tag_updates(self, profile_id, old_tags, new_tags):
         """
         Updates the active ipsets associated with the change in tags
@@ -164,23 +167,20 @@ class IpsetManager(ReferenceManager):
         _log.debug("Profile %s added tags: %s", profile_id, added_tags)
         removed_tags = old_tags - new_tags
         _log.debug("Profile %s removed tags: %s", profile_id, removed_tags)
-        for added, upd_tags in [(True, added_tags), (False, removed_tags)]:
-            for tag in upd_tags:
-                if added:
-                    self.endpoint_ids_by_tag[tag] |= endpoint_ids
-                else:
-                    self.endpoint_ids_by_tag[tag] -= endpoint_ids
-                if self._is_starting_or_live(tag):
-                    # Tag is in-use, update its members.
-                    ipset = self.objects_by_id[tag]
-                    for endpoint_id in endpoint_ids:
-                        endpoint = self.endpoints_by_ep_id[endpoint_id]
-                        for ip in map(futils.net_to_ip,
-                                      endpoint.get(self.nets_key, [])):
-                            if added:
-                                ipset.add_member(ip, async=True)
-                            else:
-                                ipset.remove_member(ip, async=True)
+        for endpoint_id in endpoint_ids:
+            endpoint = self.endpoints_by_ep_id.get(endpoint_id, {})
+            for tag_id in removed_tags:
+                for ip in self._extract_ips(endpoint):
+                    removed = self._remove_mapping(tag_id, endpoint_id, ip)
+                    if removed and self._is_starting_or_live(tag_id):
+                        _log.debug("Removing IP %s from tag %s", ip, tag_id)
+                        self.objects_by_id.remove_member(ip)
+            for tag_id in added_tags:
+                for ip in self._extract_ips(endpoint):
+                    added = self._add_mapping(tag_id, endpoint_id, ip)
+                    if added and self._is_starting_or_live(tag_id):
+                        _log.debug("Adding IP %s to tag %s", ip, tag_id)
+                        self.objects_by_id.add_member(ip)
 
     @actor_message()
     def on_endpoint_update(self, endpoint_id, endpoint):
@@ -192,67 +192,101 @@ class IpsetManager(ReferenceManager):
             old_tags = set()
 
         if endpoint is None:
-            _log.info("Endpoint %s deleted", endpoint_id)
-            if endpoint_id not in self.endpoints_by_ep_id:
-                _log.warn("Delete for unknown endpoint %s", endpoint_id)
-                return
-            # Update profile index.
-            eps_for_profile = self.endpoint_ids_by_profile_id[old_prof_id]
-            eps_for_profile.discard(endpoint_id)
-            if not eps_for_profile:
-                # Profile no longer has any endpoints using it, clean up
-                # the index.
-                _log.debug("Profile %s now unused", old_prof_id)
-                del self.endpoint_ids_by_profile_id[old_prof_id]
-            for tag in old_tags:
-                self.endpoint_ids_by_tag[tag].discard(endpoint_id)
-                if not self.endpoint_ids_by_tag[tag]:
-                    del self.endpoint_ids_by_tag[tag]
-                if self._is_starting_or_live(tag):
-                    for ip in map(futils.net_to_ip,
-                                  old_endpoint[self.nets_key]):
-                        ipset = self.objects_by_id[tag]
-                        ipset.remove_member(ip, async=True)
-            self.endpoints_by_ep_id.pop(endpoint_id, None)
+            new_tags = set()
+            new_prof_id = None
         else:
-            _log.info("Endpoint %s update received", endpoint_id)
-            new_prof_id = endpoint["profile_id"]
-            new_tags = set(self.tags_by_prof_id.get(new_prof_id, []))
+            new_prof_id = endpoint.get["profile_id"]
+            new_tags = self.tags_by_prof_id.get(new_prof_id, set())
 
-            # Calculate impact on tags due to any change of profile or IP
-            # address and queue updates to ipsets.
-            old_ips = set(map(futils.net_to_ip,
-                              old_endpoint.get(self.nets_key, [])))
-            new_ips = set(map(futils.net_to_ip,
-                              endpoint.get(self.nets_key, [])))
-            for removed_ip in old_ips - new_ips:
-                for tag in old_tags:
-                    if self._is_starting_or_live(tag):
-                        ipset = self.objects_by_id[tag]
-                        ipset.remove_member(removed_ip, async=True)
-            for tag in old_tags - new_tags:
-                self.endpoint_ids_by_tag[tag].discard(endpoint_id)
-                if self._is_starting_or_live(tag):
-                    ipset = self.objects_by_id[tag]
-                    for ip in old_ips:
-                        ipset.remove_member(ip, async=True)
-            for tag in new_tags:
-                self.endpoint_ids_by_tag[tag].add(endpoint_id)
-                if self._is_starting_or_live(tag):
-                    ipset = self.objects_by_id[tag]
-                    for ip in new_ips:
-                        ipset.add_member(ip, async=True)
+        if new_prof_id != old_prof_id:
+            self._remove_profile_index(old_prof_id, endpoint_id)
+            self._add_profile_index(new_prof_id, endpoint_id)
 
-            self.endpoints_by_ep_id[endpoint_id] = endpoint
-            if old_prof_id and old_prof_id != new_prof_id:
-                ids = self.endpoint_ids_by_profile_id[old_prof_id]
-                ids.discard(endpoint_id)
-                if not ids:
-                    del self.endpoint_ids_by_profile_id[old_prof_id]
-            self.endpoint_ids_by_profile_id[new_prof_id].add(endpoint_id)
+        added_tags = new_tags - old_tags
+        unchanged_tags = new_tags & old_tags
+        removed_tags = old_tags - new_tags
+
+        old_ips = self._extract_ips(old_endpoint)
+        new_ips = self._extract_ips(endpoint)
+
+        removed_ips_by_tag = defaultdict(set)
+        added_ips_by_tag = defaultdict(set)
+
+        # Remove *old* IPs from removed tags.
+        for tag in removed_tags:
+            for ip in old_ips:
+                ip_removed = self._remove_mapping(tag, endpoint_id, ip)
+                if ip_removed:
+                    removed_ips_by_tag[tag].add(ip)
+        # Change IPs in unchanged tags.
+        added_ips = new_ips - old_ips
+        removed_ips = old_ips - new_ips
+        for tag in unchanged_tags:
+            for ip in removed_ips:
+                ip_removed = self._remove_mapping(tag, endpoint_id, ip)
+                if ip_removed:
+                    removed_ips_by_tag[tag].add(ip)
+            for ip in added_ips:
+                ip_added = self._add_mapping(tag, endpoint_id, ip)
+                if ip_added:
+                    added_ips_by_tag[tag].add(ip)
+        # Add *new* IPs to new tags.
+        for tag in added_tags:
+            for ip in new_ips:
+                ip_added = self._add_mapping(tag, endpoint_id, ip)
+                if ip_added:
+                    added_ips_by_tag[tag].add(ip)
+
+        # Pass updates to the active ipsets.
+        for tag, ip in removed_ips_by_tag.iteritems():
+            if self._is_starting_or_live(tag):
+                self.objects_by_id[tag].remove_member(ip)
+        for tag, ip in added_ips_by_tag.iteritems():
+            if self._is_starting_or_live(tag):
+                self.objects_by_id[tag].add_member(ip)
 
         _log.info("Endpoint update complete")
 
+    def _remove_mapping(self, tag_id, endpoint_id, ip_address):
+        """
+        Removes the given tag->endpoint->IP mapping from the
+        ip_owners_by_tag and ips_in_tag indexes.
+        :return: True if the update resulted in removing that IP from the tag.
+        """
+        ep_ids = self.ip_owners_by_tag[tag_id][ip_address]
+        ep_ids.discard(endpoint_id)
+        ip_removed = False
+        if not ep_ids and ip_address in self.ips_in_tag:
+            self.ips_in_tag[tag_id].discard(ip_address)
+            del self.ip_owners_by_tag[tag_id][ip_address]
+            ip_removed = True
+        return ip_removed
+
+    def _add_mapping(self, tag_id, endpoint_id, ip_address):
+        """
+        Add the given tag->endpoint->IP mapping to the
+        ip_owners_by_tag and ips_in_tag indexes.
+        :return: True if the IP wasn't already in that tag.
+        """
+        ep_ids = self.ip_owners_by_tag[tag_id][ip_address]
+        ip_added = not bool(ep_ids)
+        ep_ids.add(endpoint_id)
+        self.ips_in_tag[tag_id].add(ip_address)
+        return ip_added
+
+    def _remove_profile_index(self, prof_id, endpoint_id):
+        if prof_id is None:
+            return
+        endpoints = self.endpoint_ids_by_profile_id[prof_id]
+        endpoints.discard(endpoint_id)
+        if not endpoints:
+            _log.debug("No more endpoints use profile %s", prof_id)
+            del self.endpoint_ids_by_profile_id[prof_id]
+
+    def _add_profile_index(self, prof_id, endpoint_id):
+        if prof_id is None:
+            return
+        self.endpoint_ids_by_profile_id[prof_id].add(endpoint_id)
 
 class ActiveIpset(RefCountedActor):
 


### PR DESCRIPTION
Previously, anycast didn't work because the ipsets management code assumed only a single endpoint could have one IP (so it would remove the IP from the ipset when _any_ endpoint with that IP went away).

I reworked the code to do all the index updates in some utility methods while at the same time changing the index structure to maintain a set of endpoints that share each IP.

This is an essential part of the anycast puzzle but we're not yet sure if it does everything that we need.  In particular, we're not sure if we correctly handle multiple routing rules for the same address in all cases.