### PR TITLE
Comment out options in example felix.cfg so Felix can use its defaults

### DIFF
--- a/etc/felix.cfg.example
+++ b/etc/felix.cfg.example
@@ -1,3 +1,3 @@
 [global]
-EtcdAddr = localhost:4001
-FelixHostname = hostname
+#EtcdAddr = localhost:4001
+#FelixHostname = hostname


### PR DESCRIPTION
Felix picks socket.gethostname by default, which will work reasonably often and is therefore a better default than 'hostname'.  Just comment out the example.