### PR TITLE
Fix endpoint updating

### DIFF
--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -175,6 +175,8 @@ class LocalEndpoint(RefCountedActor):
         # Track whether the last attempt to program the dataplane succeeded.
         # We'll force a reprogram next time we get a kick.
         self._failed = False
+        # And whether we've received an update since last time we programmed.
+        self._dirty = False
 
     @actor_event
     def on_endpoint_update(self, endpoint):
@@ -196,10 +198,15 @@ class LocalEndpoint(RefCountedActor):
         if old_profile_id != new_profile_id:
             if old_profile_id:
                 # Clean up the old profile.
+                _log.info("Profile changed, decreffing old profile %s",
+                          old_profile_id)
                 self.rules_mgr.decref(old_profile_id, async=True)
             if new_profile_id is not None:
-                _log.debug("Acquiring new profile %s", new_profile_id)
+                _log.info("Acquiring new profile %s", new_profile_id)
                 self.rules_mgr.get_and_incref(new_profile_id, async=True)
+
+        if endpoint != self.endpoint:
+            self._dirty = True
 
         # Store off the endpoint we were passed.
         self.endpoint = endpoint
@@ -264,7 +271,7 @@ class LocalEndpoint(RefCountedActor):
         is_ready = self._ready
         if not is_ready:
             _log.debug("%s not ready, waiting on %s", self, self._missing_deps)
-        if self._failed or is_ready != was_ready:
+        if self._failed or self._dirty or is_ready != was_ready:
             ifce_name = self._iface_name
             if is_ready:
                 # We've got all the info and everything is active.
@@ -285,6 +292,7 @@ class LocalEndpoint(RefCountedActor):
                 self.dispatch_chains.on_endpoint_removed(ifce_name,
                                                          async=True)
                 self._remove_chains()
+            self._dirty = False
 
     def _update_chains(self):
         updates, deps = _get_endpoint_rules(

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -163,7 +163,10 @@ class IpsetManager(ReferenceManager):
     def on_endpoint_update(self, endpoint_id, endpoint):
         old_endpoint = self.endpoints_by_ep_id.get(endpoint_id, {})
         old_prof_id = old_endpoint.get("profile_id")
-        old_tags = set(old_prof_id and self.tags_by_prof_id[old_prof_id] or [])
+        if old_prof_id:
+            old_tags = set(self.tags_by_prof_id.get(old_prof_id, []))
+        else:
+            old_tags = set()
 
         if endpoint is None:
             _log.info("Endpoint %s deleted", endpoint_id)


### PR DESCRIPTION
Mark endpoint as dirty if its data changes (before we only dealt with transitioning from ready to non-ready).

Also fix a lookup that may fail to safely default.