### PR TITLE
Avoid concurrent cleanups

### DIFF
--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -141,8 +141,8 @@ def add_route(ip_type, ip, interface, mac):
     :param str mac: MAC address. May not be none unless ips is empty.
     :raises FailedSystemCall
     """
-    if mac is None and ips:
-        raise ValueError("mac must be supplied if ips is not empty")
+    if mac is None and ip:
+        raise ValueError("mac must be supplied if ip is provided")
 
     if ip_type == futils.IPV4:
         futils.check_call(['arp', '-s', ip, mac, '-i', interface])

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -302,6 +302,7 @@ class InterfaceWatcher(Actor):
                     rta_data = rta_data[:-1]
                     if msg_type == RTM_NEWLINK:
                         _log.debug("Detected new network interface : %s", rta_data)
-                        self.update_splitter.on_interface_update(rta_data)
+                        self.update_splitter.on_interface_update(rta_data,
+                                                                 async=True)
                     else:
                         _log.debug("Network interface has gone away : %s", rta_data)

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -138,7 +138,7 @@ def add_route(ip_type, ip, interface, mac):
     :param ip_type: Type of IP (IPV4 or IPV6)
     :param str ip: IP address
     :param str interface: Interface name
-    :param str mac: MAC address. May not be none unless ips is empty.
+    :param str mac: MAC address. May not be None unless ip is None.
     :raises FailedSystemCall
     """
     if mac is None and ip:

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -88,6 +88,8 @@ def _main_greenlet(config):
         iface_watcher = InterfaceWatcher(update_splitter)
 
         _log.info("Starting actors.")
+        update_splitter.start()
+        
         v4_filter_updater.start()
         v4_nat_updater.start()
         v4_ipset_mgr.start()
@@ -104,6 +106,8 @@ def _main_greenlet(config):
         iface_watcher.start()
 
         monitored_items = [
+            update_splitter.greenlet,
+
             v4_nat_updater.greenlet,
             v4_filter_updater.greenlet,
             v4_nat_updater.greenlet,

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -89,7 +89,7 @@ def _main_greenlet(config):
 
         _log.info("Starting actors.")
         update_splitter.start()
-        
+
         v4_filter_updater.start()
         v4_nat_updater.start()
         v4_ipset_mgr.start()

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -170,7 +170,8 @@ class EtcdWatcher(Actor):
             # all the processing occur.
             update_splitter.apply_snapshot(rules_by_id,
                                            tags_by_id,
-                                           endpoints_by_id)
+                                           endpoints_by_id,
+                                           async=False)
 
             # These read only objects are no longer required, so tidy them up.
             del rules_by_id
@@ -242,18 +243,21 @@ class EtcdWatcher(Actor):
                 profile_id, rules = parse_if_rules(response)
                 if profile_id:
                     _log.info("Scheduling profile update %s", profile_id)
-                    update_splitter.on_rules_update(profile_id, rules)
+                    update_splitter.on_rules_update(profile_id, rules,
+                                                    async=False)
                     continue
                 profile_id, tags = parse_if_tags(response)
                 if profile_id:
                     _log.info("Scheduling profile update %s", profile_id)
-                    update_splitter.on_tags_update(profile_id, tags)
+                    update_splitter.on_tags_update(profile_id, tags,
+                                                   async=False)
                     continue
                 endpoint_id, endpoint = parse_if_endpoint(self.config,
                                                           response)
                 if endpoint_id:
                     _log.info("Scheduling endpoint update %s", endpoint_id)
-                    update_splitter.on_endpoint_update(endpoint_id, endpoint)
+                    update_splitter.on_endpoint_update(endpoint_id, endpoint,
+                                                       async=False)
                     continue
 
                 if response.key == DB_READY_FLAG_PATH:

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -277,13 +277,13 @@ class EtcdWatcher(Actor):
                     continue_polling = False
                 if response.key.startswith("/calico/config"):
                     _log.warning("Global config changed but we don't "
-                                 "yet support dynamic config key=%s",
-                                 response.key)
+                                 "yet support dynamic config response: %s",
+                                 response)
                     continue_polling = False
                 if response.key.startswith(self.my_config_prefix):
                     _log.warning("Config for this felix changed but we don't "
-                                 "yet support dynamic config key=%s",
-                                 response.key)
+                                 "yet support dynamic config response: %s",
+                                 response)
                     continue_polling = False
 
     def _load_config_dict(self):


### PR DESCRIPTION
Promote UpdateSplitter back to being an actor so it can manage concurrency.  Track a flag to avoid doing concurrent cleanups.

Concurrent cleanups _should_ be fine because the actors that we're calling into serialize the requests but they were producing a lot of log spam and slowing things down a lot, making it hard to track down the real issue that we were hitting today.