### PR TITLE
Don't resync when config changes

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -257,7 +257,7 @@ class EtcdWatcher(Actor):
                     continue
                 profile_id, tags = parse_if_tags(response)
                 if profile_id:
-                    _log.info("Scheduling profile update %s", profile_id)
+                    _log.info("Scheduling tags update %s", profile_id)
                     update_splitter.on_tags_update(profile_id, tags,
                                                    async=False)
                     continue
@@ -288,12 +288,10 @@ class EtcdWatcher(Actor):
                     _log.warning("Global config changed but we don't "
                                  "yet support dynamic config response: %s",
                                  response)
-                    continue_polling = False
                 if response.key.startswith(self.my_config_prefix):
                     _log.warning("Config for this felix changed but we don't "
                                  "yet support dynamic config response: %s",
                                  response)
-                    continue_polling = False
 
     def _load_config_dict(self):
         """


### PR DESCRIPTION
Conflicted with pull req 376 so I rebased on top of that.  376 needs to be merged to master before this can be reviewed.

Plugin is rewriting config with the same values, triggering a felix resync.  Disable the resync for now.