### PR TITLE
Reconnect to etcd if cluster ID changes.

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -194,7 +194,8 @@ class EtcdWatcher(Actor):
                                                 waitIndex=next_etcd_index,
                                                 recursive=True,
                                                 timeout=Timeout(connect=10,
-                                                                read=90))
+                                                                read=90),
+                                                check_cluster_id=True)
                     _log.debug("etcd response: %r", response)
                 except ReadTimeoutError:
                     # This is expected when we're doing a poll and nothing

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -18,7 +18,7 @@ felix.fetcd
 
 Etcd polling functions.
 """
-from etcd import EtcdException
+from etcd import EtcdException, EtcdClusterIdChanged
 import etcd
 import itertools
 import json
@@ -201,6 +201,11 @@ class EtcdWatcher(Actor):
                     # happened.
                     _log.debug("Read from etcd timed out, retrying.")
                     self._reconnect()
+                    continue
+                except EtcdClusterIdChanged:
+                    _log.error("Etcd cluster ID changed, reconnecting for "
+                               "full resync...")
+                    continue_polling = False
                     continue
                 except EtcdException as e:
                     # Sadly, python-etcd doesn't have a clean exception

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,4 +1,4 @@
 gevent
 greenlet
 netaddr
-python-etcd
+python-etcd==0.3.3-calico-1

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,5 @@ deps =
     mock
     coverage>=4.0a5
     unittest2
+    git+http://github.com/Metaswitch/python-etcd.git@d5e8dc849f200ecfcb207086ce0d44f238c82aa5#egg=python-etcd
 commands=nosetests --with-coverage


### PR DESCRIPTION
* Peg python-etcd to our forked version.
* Catch exception and resync in fetcd.py.