### PR TITLE
[RFC] Plugin/etcd: allow configuration of etcd host and port

### DIFF
--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -24,8 +24,20 @@ import json
 import re
 import time
 
+# OpenStack imports.
+from oslo.config import cfg
+
 # Calico imports.
 from calico.openstack.transport import CalicoTransport
+
+# Register Calico-specific options.
+calico_opts = [
+    cfg.StrOpt('etcd_host', default='localhost',
+               help="The hostname or IP of the etcd node/proxy"),
+    cfg.IntOpt('etcd_port', default=4001,
+               help="The port to use for the etcd node/proxy"),
+]
+cfg.CONF.register_opts(calico_opts, 'calico')
 
 LOG = None
 OPENSTACK_ENDPOINT_RE = re.compile(
@@ -50,7 +62,8 @@ class CalicoTransportEtcd(CalicoTransport):
 
     def initialize(self):
         # Prepare client for accessing etcd data.
-        self.client = etcd.Client()
+        self.client = etcd.Client(host=cfg.CONF.calico.etcd_host,
+                                  port=cfg.CONF.calico.etcd_port)
 
         # Spawn a green thread for periodically resynchronizing etcd against
         # the OpenStack database.


### PR DESCRIPTION
This PR has my best guess at how to allow configuration of the etcd node/proxy that the Neutron plugin connects to.  If I've got it right, the configuration should be specified in the neutron.conf file (/etc/neutron/neutron.conf) in a [calico] section, like this:

    ...
    [calico]
    etcd_host = 172.18.203.27
    # etcd_port = 4001
    ...

Unfortunately I can't currently system test this, as I don't have access to an OpenStack/Calico cluster from home.  If anyone else would like to, please go ahead - you should be able to drop the modified t_etcd.py in place on the controller, then 'service neutron-server restart'.
