### PR TITLE
Plugin etcd disappearance

### DIFF
--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -246,7 +246,7 @@ class CalicoTransportEtcd(CalicoTransport):
                         LOG.debug("Existing etcd profile key is now invalid")
                         profile_key = key_for_profile(profile_id)
                         self.client.delete(profile_key, recursive=True)
-                except KeyError:
+                except etcd.EtcdKeyNotFound:
                     LOG.info("Etcd data appears to have been reset")
 
         # Now write etcd data for each profile that we need and that we don't


### PR DESCRIPTION
I've had a little time this evening to investigate the resilience of the plugin to etcd resets, and this PR shows the result of that so far.  I've added UT to reset the etcd data at various possible points, then looked at the effect of that on the plugin code - which revealed KeyError exceptions at lines 218 and 220 where the plugin tries to read ..../rules and ..../tags for a profile.  The second commit here covers that.

I don't think this is a complete review, yet, I'm afraid, but I would hope that, with this, the plugin will have enough resilience to get through some initial testing of a moving etcd node.