### PR TITLE
Documentation for installing etcd on RHEL

### DIFF
--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -133,7 +133,7 @@ On a control node, perform the following steps:
         curl -L  https://github.com/coreos/etcd/releases/download/v2.0.9/etcd-v2.0.9-linux-amd64.tar.gz -o etcd-v2.0.9-linux-amd64.tar.gz
         tar xvf etcd-v2.0.9-linux-amd64.tar.gz
         cd etcd-v2.0.9-linux-amd64
-        mv etcd* /usr/local/bin/etcd
+        mv etcd* /usr/local/bin/
 
    - Create an etcd user::
 
@@ -405,7 +405,7 @@ On a compute node, perform the following steps:
         curl -L  https://github.com/coreos/etcd/releases/download/v2.0.9/etcd-v2.0.9-linux-amd64.tar.gz -o etcd-v2.0.9-linux-amd64.tar.gz
         tar xvf etcd-v2.0.9-linux-amd64.tar.gz
         cd etcd-v2.0.9-linux-amd64
-        mv etcd* /usr/local/bin/etcd
+        mv etcd* /usr/local/bin/
 
     - Create an etcd user::
 

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -134,15 +134,6 @@ On a control node, perform the following steps:
 6. Restart the neutron server process:
    ``service neutron-server restart``.
 
-7. Create the ``/etc/calico/acl_manager.cfg`` file by copying the
-   ``/etc/calico/acl_manager.cfg.example`` file and edit it:
-
-   -  Change the ``PluginAddress`` to the host name or IP address of the
-      controller node. Then restart the ACL manager service with:
-
-      - On Red Hat 6.5, ``initctl start calico-acl-manager``
-      - On Red Hat 7, ``systemctl restart calico-acl-manager``.
-
 Compute Node Install
 --------------------
 
@@ -354,8 +345,8 @@ On a compute node, perform the following steps:
 12. Create the ``/etc/calico/felix.cfg`` file by copying
     ``/etc/calico/felix.cfg.example`` and edit it:
 
-    -  Change the ``PluginAddress`` and ``ACLAddress`` settings to the
-       host name or IP address of the controller node.
+    -  Change the ``PluginAddress`` setting to the host name or IP address of
+       the controller node.
     -  Restart the Felix service:
 
        - on RHEL 6.5, run ``initctl start calico-felix``.

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -219,7 +219,7 @@ On a control node, perform the following steps:
    - On RHEL 6.5, run ``initctl start etcd``
 
    - On RHEL 7, run ``systemctl start etcd``. Then, run
-     ``systemctl enable etcd`` to ensure it restarts.
+     ``systemctl enable etcd`` to ensure it restarts after reboots.
 
 7. Install dependencies for python-etcd::
 
@@ -470,7 +470,7 @@ On a compute node, perform the following steps:
     - On RHEL 6.5, run ``initctl start etcd``
 
     - On RHEL 7, run ``systemctl start etcd``. Then, run
-      ``systemctl enable etcd`` to ensure it restarts.
+      ``systemctl enable etcd`` to ensure it restarts after reboots.
 
 12. If this node is not a controller, install python-etcd::
 

--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -218,7 +218,8 @@ On a control node, perform the following steps:
 
    - On RHEL 6.5, run ``initctl start etcd``
 
-   - On RHEL 7, run ``systemctl start etcd``.
+   - On RHEL 7, run ``systemctl start etcd``. Then, run
+     ``systemctl enable etcd`` to ensure it restarts.
 
 7. Install dependencies for python-etcd::
 
@@ -468,7 +469,8 @@ On a compute node, perform the following steps:
 
     - On RHEL 6.5, run ``initctl start etcd``
 
-    - On RHEL 7, run ``systemctl start etcd``.
+    - On RHEL 7, run ``systemctl start etcd``. Then, run
+      ``systemctl enable etcd`` to ensure it restarts.
 
 12. If this node is not a controller, install python-etcd::
 


### PR DESCRIPTION
This change removes references to the ACL manager and instead documents how to download and install etcd on RHEL.

The next step of this is to get some tests of these instructions: that's with you @DaveLangridge.