### PR TITLE
Depend on recent version of python-etcd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Depends:
  calico-common (= ${binary:Version}),
  python-six,
  python-gevent,
+ python-etcd (>= 0.3.3-1calico0.15),
  ${misc:Depends},
  ${python:Depends}
 Description: Project Calico virtual networking for cloud data centers.
@@ -71,6 +72,7 @@ Depends:
  ipset,
  python-netaddr,
  python-gevent,
+ python-etcd (>= 0.3.3-1calico0.15),
  ${misc:Depends},
  ${python:Depends},
  ${shlibs:Depends}


### PR DESCRIPTION
This updates our debian packages to depend on python-etcd explicitly, and moreover to depend on recent versions of it.

Resolves #392.

Hard to work out who best to assign this to, so I'm giving it to @matthewdupre as release owner for 0.16.

