### PR TITLE
Add missing async argument when decrefing actor.

### DIFF
--- a/calico/felix/refcount.py
+++ b/calico/felix/refcount.py
@@ -279,7 +279,7 @@ class RefHelper(object):
             # Deleted while we were waiting.
             _log.debug("Object %s was discarded while waiting for its ref",
                        obj_id)
-            self._ref_mgr.decref(obj_id)
+            self._ref_mgr.decref(obj_id, async=True)
         now_ready = self.ready
         if not was_ready and now_ready:
             _log.debug("Acquired all references, calling ready callback")


### PR DESCRIPTION
Matt, as discussed, this branch will always assert due to the missing argument.