### PR TITLE
Be more defensive in etcd polling, catch various HTTP-related exceptions...

### DIFF
--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -21,16 +21,12 @@ The main logic for Felix.
 """
 
 # Monkey-patch before we do anything else...
-from calico.felix.devices import InterfaceWatcher
-from calico.felix.endpoint import EndpointManager
-from calico.felix.fetcd import EtcdWatcher
-from calico.felix.ipsets import IpsetManager
 from gevent import monkey
 monkey.patch_all()
 
+import logging
 import os
 
-import logging
 import gevent
 
 from calico import common
@@ -41,6 +37,10 @@ from calico.felix.frules import install_global_rules
 from calico.felix.splitter import UpdateSplitter
 from calico.felix.config import Config
 from calico.felix.futils import IPV4, IPV6
+from calico.felix.devices import InterfaceWatcher
+from calico.felix.endpoint import EndpointManager
+from calico.felix.fetcd import EtcdWatcher
+from calico.felix.ipsets import IpsetManager
 
 _log = logging.getLogger(__name__)
 

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -18,7 +18,9 @@ felix.fetcd
 
 Etcd polling functions.
 """
-from etcd import EtcdException, EtcdClusterIdChanged, EtcdKeyNotFound
+import socket
+from etcd import (EtcdException, EtcdClusterIdChanged, EtcdKeyNotFound,
+                  EtcdEventIndexCleared)
 import etcd
 import itertools
 import json
@@ -26,7 +28,7 @@ import logging
 import gevent
 from types import StringTypes
 from urllib3 import Timeout
-from urllib3.exceptions import ReadTimeoutError
+from urllib3.exceptions import ReadTimeoutError, ConnectTimeoutError, HTTPError
 
 from calico import common
 from calico.datamodel_v1 import (VERSION_DIR, READY_KEY, CONFIG_DIR,
@@ -200,10 +202,27 @@ class EtcdWatcher(Actor):
                                                                 read=90),
                                                 check_cluster_id=True)
                     _log.debug("etcd response: %r", response)
+                except ConnectTimeoutError:
+                    _log.warning("Connection timeout when trying to  connect "
+                                 "to etcd")
+                    self._reconnect()
+                    continue
                 except ReadTimeoutError:
                     # This is expected when we're doing a poll and nothing
                     # happened.
                     _log.debug("Read from etcd timed out, retrying.")
+                    self._reconnect()
+                    continue
+                except socket.timeout:
+                    # That this leaks out appears to be an artifact of running
+                    # urllib3 on top of gevent.  Be defensive and reconnect.
+                    _log.debug("Raw socket.timeout leaked out of "
+                               "python-etcd.  Retrying.")
+                    self._reconnect()
+                    continue
+                except HTTPError:
+                    _log.exception("Unexpected error from urllib3, "
+                                   "reconnecting to etcd...")
                     self._reconnect()
                     continue
                 except EtcdClusterIdChanged:
@@ -211,11 +230,16 @@ class EtcdWatcher(Actor):
                                "full resync...")
                     continue_polling = False
                     continue
+                except EtcdEventIndexCleared:
+                    # Our poll fell too far behind and etcd can no longer
+                    # service our request.
+                    _log.error("Fell too far behind current etcd index, "
+                               "triggering a full resync.")
+                    continue_polling = False
                 except EtcdException as e:
-                    # Sadly, python-etcd doesn't have a clean exception
-                    # hierarchy; look at the message.  We only log the stack
-                    # trace for errors we're not expecting to avoid copious
-                    # log spam.
+                    # Sadly, python-etcd doesn't have a dedicated exception
+                    # for the "no more machines in cluster" error. Parse the
+                    # message:
                     msg = (e.message or "unknown").lower()
                     if "no more machines" in msg:
                         # This error comes from python-etcd when it can't
@@ -225,14 +249,9 @@ class EtcdWatcher(Actor):
                         # That'd recover from errors caused by resource
                         # exhaustion/leaks.
                         _log.error("Connection to etcd failed, will retry.")
-                    elif "requested index is outdated" in msg:
-                        # Error from etcd itself, this is fatal for our event
-                        # poll, we have to do a full resync.
-                        _log.error("Fell too far behind current etcd index, "
-                                   "triggering a full resync.")
-                        continue_polling = False
                     else:
-                        # Assume any other errors are fatal.
+                        # Assume any other errors are fatal to our poll and
+                        # do a full resync.
                         _log.exception("Unknown etcd error %r; doing resync.",
                                        e.message)
                         continue_polling = False

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -215,8 +215,9 @@ class EtcdWatcher(Actor):
                 except socket.timeout:
                     # That this leaks out appears to be an artifact of running
                     # urllib3 on top of gevent.  Be defensive and reconnect.
-                    _log.debug("Raw socket.timeout leaked out of "
-                               "python-etcd.  Retrying.")
+                    _log.warning("Raw socket.timeout leaked out of "
+                                 "python-etcd.  Reconnecting...",
+                                 exc_info=True)
                     self._reconnect()
                 except HTTPError:
                     _log.exception("Unexpected error from urllib3, "


### PR DESCRIPTION
python-etcd isn't great at wrapping all exceptions that urllib3 and the libraries underneath it can raise.  Be defensive and catch all exceptions from urllib3 as well as socker.timeout, which seems to get leaked when we're running on top of gevent.

Also fix the import order in felix.py.  We were importing some items before we monkey-patched using gevent.  That's asking for trouble.  (I thought I'd already fixed that :-()

Should fix #415.