### PR TITLE
Fix ICMP rule generation in plugin; add missing support for ICMP code

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -517,7 +517,17 @@ def validate_rules(rules):
                 issues.append("Invalid action in rule %s." % rule)
 
             icmp_type = rule.get('icmp_type')
-            #TODO: firewall the icmp_type too
+            if icmp_type is not None:
+                if not 0 <= icmp_type <= 255:
+                    issues.append("ICMP type is out of range.")
+            icmp_code = rule.get("icmp_code")
+            if icmp_code is not None:
+                if not 0 <= icmp_code <= 255:
+                    issues.append("ICMP code is out of range.")
+                if icmp_type is None:
+                    # FIXME ICMP code without ICMP type not supported by iptables
+                    # Firewall against that for now.
+                    issues.append("ICMP code specified without ICMP type.")
 
     if issues:
         raise ValidationFailed(" ".join(issues))

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -270,75 +270,11 @@ class CalicoTransportEtcd(CalicoTransport):
         for sgid in self.profile_tags(profile_id):
             for rule in self.sgs[sgid]['security_group_rules']:
                 LOG.info("Neutron rule  %s : %s", profile_id, rule)
-
-                ethertype = rule['ethertype']
-                etcd_rule = {}
-
-                # Map the ethertype field from Neutron to etcd format.
-                etcd_rule['ip_version'] = {'IPv4': 4,
-                                           'IPv6': 6}[ethertype]
-
-                # Map the protocol field from Neutron to etcd format.
-                if rule['protocol'] is None or rule['protocol'] == -1:
-                    pass
-                elif rule['protocol'] == 'icmp':
-                    etcd_rule['protocol'] = {'IPv4': 'icmp',
-                                             'IPv6': 'icmpv6'}[ethertype]
-                else:
-                    etcd_rule['protocol'] = rule['protocol']
-
-                # OpenStack (sometimes) represents 'any IP address' by setting
-                # both 'remote_group_id' and 'remote_ip_prefix' to None.  We
-                # translate that to an explicit 0.0.0.0/0 (for IPv4) or ::/0
-                # (for IPv6).
-                net = rule['remote_ip_prefix']
-                if not (net or rule['remote_group_id']):
-                    net = {'IPv4': '0.0.0.0/0',
-                           'IPv6': '::/0'}[ethertype]
-
-                port_spec = None
-                if rule['protocol'] == 'icmp':
-                    # OpenStack stashes the ICMP match criteria in
-                    # port_range_min/max.
-                    icmp_type = rule['port_range_min']
-                    if icmp_type is not None and icmp_type != -1:
-                        etcd_rule['icmp_type'] = icmp_type
-                    icmp_code = rule['port_range_max']
-                    if icmp_code is not None and icmp_code != -1:
-                        etcd_rule['icmp_code'] = icmp_code
-                else:
-
-                    # src/dst_ports is a list in which each entry can be a
-                    # single number, or a string describing a port range.
-                    if rule['port_range_min'] == -1:
-                        port_spec = ['1:65535']
-                    elif rule['port_range_min'] == rule['port_range_max']:
-                        if rule['port_range_min'] is not None:
-                            port_spec = [rule['port_range_min']]
-                    else:
-                        port_spec = ['%s:%s' % (rule['port_range_min'],
-                                                rule['port_range_max'])]
-
-                # Put it all together and add to either the inbound or the
-                # outbound list.
+                etcd_rule = _neutron_rule_to_etcd_rule(rule)
                 if rule['direction'] == 'ingress':
-                    if rule['remote_group_id'] is not None:
-                        etcd_rule['src_tag'] = rule['remote_group_id']
-                    if net is not None:
-                        etcd_rule['src_net'] = net
-                    if port_spec is not None:
-                        etcd_rule['dst_ports'] = port_spec
                     inbound.append(etcd_rule)
-                    LOG.info("=> Inbound Calico rule %s" % etcd_rule)
                 else:
-                    if rule['remote_group_id'] is not None:
-                        etcd_rule['dst_tag'] = rule['remote_group_id']
-                    if net is not None:
-                        etcd_rule['dst_net'] = net
-                    if port_spec is not None:
-                        etcd_rule['dst_ports'] = port_spec
                     outbound.append(etcd_rule)
-                    LOG.info("=> Outbound Calico rule %s" % etcd_rule)
 
         return {'inbound_rules': inbound, 'outbound_rules': outbound}
 
@@ -407,3 +343,73 @@ class CalicoTransportEtcd(CalicoTransport):
             # TODO Set this flag only once we're really ready!
             LOG.info('%s -> true', READY_KEY)
             self.client.write(READY_KEY, 'true')
+
+def _neutron_rule_to_etcd_rule(rule):
+    """
+    Translate a single Neutron rule dict to a single dict in our
+    etcd format.
+    """
+    ethertype = rule['ethertype']
+    etcd_rule = {}
+    # Map the ethertype field from Neutron to etcd format.
+    etcd_rule['ip_version'] = {'IPv4': 4,
+                               'IPv6': 6}[ethertype]
+    # Map the protocol field from Neutron to etcd format.
+    if rule['protocol'] is None or rule['protocol'] == -1:
+        pass
+    elif rule['protocol'] == 'icmp':
+        etcd_rule['protocol'] = {'IPv4': 'icmp',
+                                 'IPv6': 'icmpv6'}[ethertype]
+    else:
+        etcd_rule['protocol'] = rule['protocol']
+
+    # OpenStack (sometimes) represents 'any IP address' by setting
+    # both 'remote_group_id' and 'remote_ip_prefix' to None.  We
+    # translate that to an explicit 0.0.0.0/0 (for IPv4) or ::/0
+    # (for IPv6).
+    net = rule['remote_ip_prefix']
+    if not (net or rule['remote_group_id']):
+        net = {'IPv4': '0.0.0.0/0',
+               'IPv6': '::/0'}[ethertype]
+    port_spec = None
+    if rule['protocol'] == 'icmp':
+        # OpenStack stashes the ICMP match criteria in
+        # port_range_min/max.
+        icmp_type = rule['port_range_min']
+        if icmp_type is not None and icmp_type != -1:
+            etcd_rule['icmp_type'] = icmp_type
+        icmp_code = rule['port_range_max']
+        if icmp_code is not None and icmp_code != -1:
+            etcd_rule['icmp_code'] = icmp_code
+    else:
+        # src/dst_ports is a list in which each entry can be a
+        # single number, or a string describing a port range.
+        if rule['port_range_min'] == -1:
+            port_spec = ['1:65535']
+        elif rule['port_range_min'] == rule['port_range_max']:
+            if rule['port_range_min'] is not None:
+                port_spec = [rule['port_range_min']]
+        else:
+            port_spec = ['%s:%s' % (rule['port_range_min'],
+                                    rule['port_range_max'])]
+
+    # Put it all together and add to either the inbound or the
+    # outbound list.
+    if rule['direction'] == 'ingress':
+        if rule['remote_group_id'] is not None:
+            etcd_rule['src_tag'] = rule['remote_group_id']
+        if net is not None:
+            etcd_rule['src_net'] = net
+        if port_spec is not None:
+            etcd_rule['dst_ports'] = port_spec
+        LOG.info("=> Inbound Calico rule %s" % etcd_rule)
+    else:
+        if rule['remote_group_id'] is not None:
+            etcd_rule['dst_tag'] = rule['remote_group_id']
+        if net is not None:
+            etcd_rule['dst_net'] = net
+        if port_spec is not None:
+            etcd_rule['dst_ports'] = port_spec
+        LOG.info("=> Outbound Calico rule %s" % etcd_rule)
+
+    return etcd_rule

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -22,6 +22,7 @@ import eventlet
 import json
 import mock
 import unittest
+from calico.felix import fetcd
 
 import calico.openstack.test.lib as lib
 import calico.openstack.mech_calico as mech_calico
@@ -547,6 +548,15 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
     def assertNeutronToEtcd(self, neutron_rule, exp_etcd_rule):
         etcd_rule = t_etcd._neutron_rule_to_etcd_rule(neutron_rule)
         self.assertEqual(etcd_rule, exp_etcd_rule)
+
+        # Check felix is happy with generated rule.
+        if neutron_rule["direction"] == "ingress":
+            rules = {"inbound_rules": [neutron_rule],
+                     "outbound_rules": []}
+        else:
+            rules = {"outbound_rules": [neutron_rule],
+                     "inbound_rules": []}
+        fetcd.validate_rules(rules)
 
 
 def neutron_rule(overrides):

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -499,7 +499,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
 
     def test_neutron_rule_to_etcd_rule_icmp(self):
         # No type/code specified
-        self.assertNeutronToEtcd(neutron_rule({
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
             "ethertype": "IPv4",
             "protocol": "icmp",
         }), {
@@ -508,7 +508,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
             'src_net': '0.0.0.0/0',
         })
         # Type/code wildcarded, same as above.
-        self.assertNeutronToEtcd(neutron_rule({
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
             "ethertype": "IPv4",
             "protocol": "icmp",
             "port_range_min": -1,
@@ -519,7 +519,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
             'src_net': '0.0.0.0/0',
         })
         # Type and code.
-        self.assertNeutronToEtcd(neutron_rule({
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
             "ethertype": "IPv4",
             "protocol": "icmp",
             "port_range_min": 123,
@@ -532,7 +532,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
             'icmp_code': 100,
         })
         # Type and code, IPv6.
-        self.assertNeutronToEtcd(neutron_rule({
+        self.assertNeutronToEtcd(_neutron_rule_from_dict({
             "ethertype": "IPv6",
             "protocol": "icmp",
             "port_range_min": 123,
@@ -559,7 +559,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         fetcd.validate_rules(rules)
 
 
-def neutron_rule(overrides):
+def _neutron_rule_from_dict(overrides):
     rule = {
         "ethertype": "IPv4",
         "protocol": None,


### PR DESCRIPTION
* Plugin was generating rules with source/dest port as well as ICMP type/code, which felix was asserting on.  Fixed by moving the ICMP code into an alternating branch with the source/dest port code.
* Felix was missing support for the ICMP code.  I've added this in but there's a caveat: felix can only match on icmp type or icmp type and code; it can't match on code alone, which does seem to be allowed in OpenStack.  Need to discuss the correct approach here.  (Expanding to 255 rules seems overkill?)
* Added in missing validation for ICMP type/code.
* Added plugin UTs.

Not to reviewer: the first commit in the pull req makes the change to the plugin.  "Add UTs" commit refactors the plugin code to make it easier to test the rule creation in isolation.

Fixes #414.