### PR TITLE
When reconnecting, copy old cluster ID from previous etcd Client

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -214,7 +214,7 @@ class EtcdWatcher(Actor):
                 except (ReadTimeoutError, SocketTimeout) as e:
                     # This is expected when we're doing a poll and nothing
                     # happened. socket timeout doesn't seem to be caught by
-                    # urllib3 0.7.1.  Simply reconnect.
+                    # urllib3 1.7.1.  Simply reconnect.
                     _log.debug("Read from etcd timed out (%r), retrying.", e)
                     # Force a reconnect to ensure urllib3 doesn't recycle the
                     # connection.  (We were seeing this with urllib3 1.7.1.)

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,4 +1,4 @@
 gevent
 greenlet
 netaddr
-python-etcd>=0.3.3-calico-1
+python-etcd==0.3.3-calico-2

--- a/felix_requirements.txt
+++ b/felix_requirements.txt
@@ -1,4 +1,4 @@
 gevent
 greenlet
 netaddr
-python-etcd==0.3.3-calico-2
+python-etcd>=0.3.3-calico-2

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps =
     mock
     coverage>=4.0a5
     unittest2
-    git+http://github.com/Metaswitch/python-etcd.git@d5e8dc849f200ecfcb207086ce0d44f238c82aa5#egg=python-etcd
+    git+http://github.com/Metaswitch/python-etcd.git@0.3.3-calico-2#egg=python-etcd
 commands=nosetests --with-coverage


### PR DESCRIPTION
IMPORTANT: relies on new python-etcd version https://github.com/Metaswitch/python-etcd/pull/3.  that needs to be reviewed/merged/packaged first.

If we reconnect without doing a resync then we were clobbering the cluster ID that our version of python-etcd maintains.  This fix copies the cluster ID to the newly created client except when we resync.