### PR TITLE
Use commit id instead of tag in tox dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps =
     mock
     coverage>=4.0a5
     unittest2
-    git+http://github.com/Metaswitch/python-etcd.git@0.3.3-calico-2#egg=python-etcd
+    git+http://github.com/Metaswitch/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
 commands=nosetests --with-coverage


### PR DESCRIPTION
For some reason using the tag seems to cause (intermittent?) failures in our
UTs.  It seems to be resolved by reverting to the commit id, so I'm just going
to do that rather wasting time investigating.