### PR TITLE
Add missing jump target to ICMPv6 from endpoint rule.

### DIFF
--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -432,7 +432,8 @@ def _get_endpoint_rules(suffix, iface, ip_version, local_ips, mac, profile_id):
     from_chain = ["--flush %s" % from_chain_name]
     if ip_version == 6:
         # In ipv6 only, allows all ICMP traffic from this endpoint to anywhere.
-        from_chain.append("--append %s --protocol ipv6-icmp" % from_chain_name)
+        from_chain.append("--append %s --protocol ipv6-icmp --jump RETURN" %
+                          from_chain_name)
 
     # Conntrack rules.
     from_chain.append("--append %s --match conntrack --ctstate INVALID "


### PR DESCRIPTION
@neiljerram this should fix the ICMP issue you were seeing but I can't test it locally without an otherwise working IPv6 setup.  Do you have time to give it a spin?