### PR TITLE
Document that Felix requires a config file, or it won't start on RHEL

### DIFF
--- a/docs/source/redhat-opens-install.rst
+++ b/docs/source/redhat-opens-install.rst
@@ -538,6 +538,15 @@ On a compute node, perform the following steps:
 
          initctl start bird
 
+15. Create the ``/etc/calico/felix.cfg`` file by copying
+    ``/etc/calico/felix.cfg.example``.  Ordinarily the default values should be
+    used, but see :doc:`configuration` for more details.
+
+16. Restart the Felix service:
+
+       - on RHEL 6.5, run ``initctl start calico-felix``.
+       - on RHEL 7, run ``systemctl restart calico-felix``.
+
 Next Steps
 ----------
 


### PR DESCRIPTION
@matthewdupre Pointed out that our current RHEL instructions were missing a key step; if there is no Felix configuration file, then Felix will fail to start.