### PR TITLE
Dispatch chains review and test.

### DIFF
--- a/calico/felix/dispatch.py
+++ b/calico/felix/dispatch.py
@@ -21,7 +21,9 @@ per-endpoint chains.
 """
 import logging
 from calico.felix.actor import Actor, actor_message
-from calico.felix.frules import CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT
+from calico.felix.frules import (
+    CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT, chain_names, interface_to_suffix
+)
 
 _log = logging.getLogger(__name__)
 
@@ -115,7 +117,6 @@ class DispatchChains(Actor):
         from_deps = set()
         dependencies = {CHAIN_TO_ENDPOINT: to_deps,
                         CHAIN_FROM_ENDPOINT: from_deps}
-        from calico.felix.endpoint import chain_names, interface_to_suffix
         for iface in self.iface_to_ep_id:
             # Add rule to global chain to direct traffic to the
             # endpoint-specific one.  Note that we use --goto, which means
@@ -139,5 +140,7 @@ class DispatchChains(Actor):
                                              async=False)
 
     def __str__(self):
-        return self.__class__.__name__ + "<ipv%s,entries=%s>" % \
+        return (
+            self.__class__.__name__ + "<ipv%s,entries=%s>" %
             (self.ip_version, len(self.iface_to_ep_id))
+        )

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -29,7 +29,8 @@ from calico.felix.refcount import ReferenceManager, RefCountedActor
 from calico.felix.dispatch import DispatchChains
 from calico.felix.profilerules import RulesManager
 from calico.felix.frules import (CHAIN_TO_PREFIX, profile_to_chain_name,
-                                 CHAIN_FROM_PREFIX, commented_drop_fragment)
+                                 CHAIN_FROM_PREFIX, commented_drop_fragment,
+                                 interface_to_suffix, chain_names)
 
 _log = logging.getLogger(__name__)
 
@@ -382,19 +383,6 @@ class LocalEndpoint(RefCountedActor):
         return ("Endpoint<%s,id=%s,iface=%s>" %
                 (self.ip_type, self.endpoint_id,
                  self._iface_name or "unknown"))
-
-
-def interface_to_suffix(config, iface_name):
-    suffix = iface_name.replace(config.IFACE_PREFIX, "", 1)
-    # The suffix is surely not very long, but make sure.
-    suffix = futils.uniquely_shorten(suffix, 16)
-    return suffix
-
-
-def chain_names(endpoint_suffix):
-    to_chain_name = (CHAIN_TO_PREFIX + endpoint_suffix)
-    from_chain_name = (CHAIN_FROM_PREFIX + endpoint_suffix)
-    return to_chain_name, from_chain_name
 
 
 def _get_endpoint_rules(suffix, iface, ip_version, local_ips, mac, profile_id):

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -89,7 +89,7 @@ class EndpointManager(ReferenceManager):
         for ep_id, ep in endpoints_by_id.iteritems():
             if ep and ep["host"] == self.config.HOSTNAME and ep.get("name"):
                 local_iface_name_to_ep_id[ep.get("name")] = ep_id
-        self.dispatch_chains.apply_snapshot(local_iface_name_to_ep_id,
+        self.dispatch_chains.apply_snapshot(local_iface_name_to_ep_id.keys(),
                                             async=True)
 
         for endpoint_id, endpoint in endpoints_by_id.iteritems():
@@ -293,7 +293,7 @@ class LocalEndpoint(RefCountedActor):
                 _log.info("%s became ready to program.", self)
                 self._update_chains()
                 self.dispatch_chains.on_endpoint_added(
-                    self._iface_name, self.endpoint_id, async=True)
+                    self._iface_name, async=True)
             else:
                 # We were active but now we're not, withdraw the dispatch rule
                 # and our chain.  We must do this to allow iptables to remove

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -332,5 +332,18 @@ def _rule_to_iptables_fragment(chain_name, rule, ip_version, tag_to_ipset,
     return " ".join(str(x) for x in update_fragments)
 
 
+def interface_to_suffix(config, iface_name):
+    suffix = iface_name.replace(config.IFACE_PREFIX, "", 1)
+    # The suffix is surely not very long, but make sure.
+    suffix = futils.uniquely_shorten(suffix, 16)
+    return suffix
+
+
+def chain_names(endpoint_suffix):
+    to_chain_name = (CHAIN_TO_PREFIX + endpoint_suffix)
+    from_chain_name = (CHAIN_FROM_PREFIX + endpoint_suffix)
+    return to_chain_name, from_chain_name
+
+
 class UnsupportedICMPType(Exception):
     pass

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -57,17 +57,20 @@ class TestDispatchChains(BaseTestCase):
         # We only care about positional arguments
         args = args[0]
 
-        # The fact that sets are used means we can't demand ordering, so do
-        # ItemsEqual.
+        # The DispatchChains object stores the endpoints in a set, which means
+        # that when it builds the list of goto rules they can be emitted in any
+        # order. However, the DROP rule must always appear at the end. To do
+        # that, first check that the updates contain the same rules in any
+        # order (using assertItemsEqual), and then confirm that the last rule
+        # is the DROP rule.
         self.assertItemsEqual(args[0][CHAIN_TO_ENDPOINT], to_updates)
         self.assertItemsEqual(args[0][CHAIN_FROM_ENDPOINT], from_updates)
-        self.assertEqual(args[1][CHAIN_TO_ENDPOINT], to_chain_names)
-        self.assertEqual(args[1][CHAIN_FROM_ENDPOINT], from_chain_names)
-
-        # We do want to ensure that the drop rule really is last in both
-        # update lists.
         self.assertEqual(args[0][CHAIN_TO_ENDPOINT][-1], to_updates[-1])
         self.assertEqual(args[0][CHAIN_FROM_ENDPOINT][-1], from_updates[-1])
+
+        # Confirm that the dependency sets match.
+        self.assertEqual(args[1][CHAIN_TO_ENDPOINT], to_chain_names)
+        self.assertEqual(args[1][CHAIN_FROM_ENDPOINT], from_chain_names)
 
     def test_applying_snapshot_clean(self):
         """

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014, 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+felix.test.test_dispatch
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests of the actor that controls the top-level dispatch chain.
+"""
+import collections
+
+import mock
+
+from calico.felix.test.base import BaseTestCase
+from calico.felix.dispatch import (
+    DispatchChains, CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT
+)
+
+
+# A mocked config object for use with interface_to_suffix.
+Config = collections.namedtuple('Config', ['IFACE_PREFIX'])
+
+
+class TestDispatchChains(BaseTestCase):
+    """
+    Tests for the DispatchChains actor.
+    """
+    def setUp(self):
+        super(TestDispatchChains, self).setUp()
+        self.iptables_updater = mock.MagicMock()
+        self.config = Config('tap')
+
+    def getDispatchChain(self):
+        return DispatchChains(
+            config=self.config,
+            ip_version=4,
+            iptables_updater=self.iptables_updater
+        )
+
+    def assert_iptables_update(self,
+                               args,
+                               to_updates,
+                               from_updates,
+                               to_chain_names,
+                               from_chain_names):
+        # We only care about positional arguments
+        args = args[0]
+
+        # The fact that sets are used means we can't demand ordering, so do
+        # ItemsEqual.
+        self.assertItemsEqual(args[0][CHAIN_TO_ENDPOINT], to_updates)
+        self.assertItemsEqual(args[0][CHAIN_FROM_ENDPOINT], from_updates)
+        self.assertEqual(args[1][CHAIN_TO_ENDPOINT], to_chain_names)
+        self.assertEqual(args[1][CHAIN_FROM_ENDPOINT], from_chain_names)
+
+        # We do want to ensure that the drop rule really is last in both
+        # update lists.
+        self.assertEqual(args[0][CHAIN_TO_ENDPOINT][-1], to_updates[-1])
+        self.assertEqual(args[0][CHAIN_FROM_ENDPOINT][-1], from_updates[-1])
+
+    def test_applying_snapshot_clean(self):
+        """
+        Tests that a snapshot can be applied to a previously unused actor.
+        """
+        d = self.getDispatchChain()
+
+        ifaces = ['tapabcdef', 'tap123456', 'tapa7d849']
+        d.apply_snapshot(ifaces, async=True)
+        self.step_actor(d)
+
+        from_updates = [
+            '--append felix-FROM-ENDPOINT --in-interface tapabcdef --goto felix-from-abcdef',
+            '--append felix-FROM-ENDPOINT --in-interface tap123456 --goto felix-from-123456',
+            '--append felix-FROM-ENDPOINT --in-interface tapa7d849 --goto felix-from-a7d849',
+            '--append felix-FROM-ENDPOINT --jump DROP',
+        ]
+        to_updates = [
+            '--append felix-TO-ENDPOINT --out-interface tapabcdef --goto felix-to-abcdef',
+            '--append felix-TO-ENDPOINT --out-interface tap123456 --goto felix-to-123456',
+            '--append felix-TO-ENDPOINT --out-interface tapa7d849 --goto felix-to-a7d849',
+            '--append felix-TO-ENDPOINT --jump DROP',
+        ]
+        from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-a7d849'])
+        to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-a7d849'])
+
+        self.iptables_updater.assertCalledOnce()
+        args = self.iptables_updater.rewrite_chains.call_args
+        self.assert_iptables_update(
+            args, to_updates, from_updates, to_chain_names, from_chain_names
+        )
+
+    def test_applying_snapshot_dirty(self):
+        """
+        Tests that a snapshot can be applied to an actor that used to have
+        state.
+        """
+        d = self.getDispatchChain()
+
+        # Insert some chains I don't want to see.
+        d.apply_snapshot(['tapxyz', 'tap889900', 'tapundefined'], async=True)
+        self.step_actor(d)
+
+        ifaces = ['tapabcdef', 'tap123456', 'tapa7d849']
+        d.apply_snapshot(ifaces, async=True)
+        self.step_actor(d)
+
+        from_updates = [
+            '--append felix-FROM-ENDPOINT --in-interface tapabcdef --goto felix-from-abcdef',
+            '--append felix-FROM-ENDPOINT --in-interface tap123456 --goto felix-from-123456',
+            '--append felix-FROM-ENDPOINT --in-interface tapa7d849 --goto felix-from-a7d849',
+            '--append felix-FROM-ENDPOINT --jump DROP',
+        ]
+        to_updates = [
+            '--append felix-TO-ENDPOINT --out-interface tapabcdef --goto felix-to-abcdef',
+            '--append felix-TO-ENDPOINT --out-interface tap123456 --goto felix-to-123456',
+            '--append felix-TO-ENDPOINT --out-interface tapa7d849 --goto felix-to-a7d849',
+            '--append felix-TO-ENDPOINT --jump DROP',
+        ]
+        from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-a7d849'])
+        to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-a7d849'])
+
+        self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
+        args = self.iptables_updater.rewrite_chains.call_args
+        self.assert_iptables_update(
+            args, to_updates, from_updates, to_chain_names, from_chain_names
+        )
+
+    def test_applying_empty_snapshot(self):
+        """
+        Tests that an empty snapshot can be applied to an actor that used to
+        have state.
+        """
+        d = self.getDispatchChain()
+
+        # Insert some chains I don't want to see.
+        d.apply_snapshot(['tapxyz', 'tap889900', 'tapundefined'], async=True)
+        self.step_actor(d)
+
+        # Clear it out
+        d.apply_snapshot([], async=True)
+        self.step_actor(d)
+
+        from_updates = [
+            '--append felix-FROM-ENDPOINT --jump DROP',
+        ]
+        to_updates = [
+            '--append felix-TO-ENDPOINT --jump DROP',
+        ]
+        from_chain_names = set()
+        to_chain_names = set()
+
+        self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
+        args = self.iptables_updater.rewrite_chains.call_args
+        self.assert_iptables_update(
+            args, to_updates, from_updates, to_chain_names, from_chain_names
+        )
+
+    def test_on_endpoint_added_simple(self):
+        """
+        Tests that adding an endpoint, adds it to the state.
+        """
+        d = self.getDispatchChain()
+
+        # Insert some basic chains.
+        d.apply_snapshot(['tapabcdef', 'tap123456'], async=True)
+        self.step_actor(d)
+
+        # Add one endpoint.
+        d.on_endpoint_added('tapa7d849', async=True)
+        self.step_actor(d)
+
+        from_updates = [
+            '--append felix-FROM-ENDPOINT --in-interface tapabcdef --goto felix-from-abcdef',
+            '--append felix-FROM-ENDPOINT --in-interface tap123456 --goto felix-from-123456',
+            '--append felix-FROM-ENDPOINT --in-interface tapa7d849 --goto felix-from-a7d849',
+            '--append felix-FROM-ENDPOINT --jump DROP',
+        ]
+        to_updates = [
+            '--append felix-TO-ENDPOINT --out-interface tapabcdef --goto felix-to-abcdef',
+            '--append felix-TO-ENDPOINT --out-interface tap123456 --goto felix-to-123456',
+            '--append felix-TO-ENDPOINT --out-interface tapa7d849 --goto felix-to-a7d849',
+            '--append felix-TO-ENDPOINT --jump DROP',
+        ]
+        from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-a7d849'])
+        to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-a7d849'])
+
+        self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
+        args = self.iptables_updater.rewrite_chains.call_args
+        self.assert_iptables_update(
+            args, to_updates, from_updates, to_chain_names, from_chain_names
+        )
+
+    def test_on_endpoint_added_idempotent(self):
+        """
+        Tests that adding an endpoint that's already present does nothing.
+        """
+        d = self.getDispatchChain()
+
+        # Insert some basic chains.
+        d.apply_snapshot(['tapabcdef', 'tap123456', 'tapa7d849'], async=True)
+        self.step_actor(d)
+
+        # Add an endpoint we already have.
+        d.on_endpoint_added('tapabcdef', async=True)
+        self.step_actor(d)
+
+        # Confirm that we only got called once.
+        self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 1)
+
+    def test_on_endpoint_removed_basic(self):
+        """
+        Tests that we can remove an endpoint.
+        """
+        d = self.getDispatchChain()
+
+        # Insert some basic chains.
+        d.apply_snapshot(['tapabcdef', 'tap123456', 'tapa7d849'], async=True)
+        self.step_actor(d)
+
+        # Remove an endpoint.
+        d.on_endpoint_removed('tapabcdef', async=True)
+        self.step_actor(d)
+
+        from_updates = [
+            '--append felix-FROM-ENDPOINT --in-interface tap123456 --goto felix-from-123456',
+            '--append felix-FROM-ENDPOINT --in-interface tapa7d849 --goto felix-from-a7d849',
+            '--append felix-FROM-ENDPOINT --jump DROP',
+        ]
+        to_updates = [
+            '--append felix-TO-ENDPOINT --out-interface tap123456 --goto felix-to-123456',
+            '--append felix-TO-ENDPOINT --out-interface tapa7d849 --goto felix-to-a7d849',
+            '--append felix-TO-ENDPOINT --jump DROP',
+        ]
+        from_chain_names = set(['felix-from-123456', 'felix-from-a7d849'])
+        to_chain_names = set(['felix-to-123456', 'felix-to-a7d849'])
+
+        # Confirm that we got called twice.
+        self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
+        args = self.iptables_updater.rewrite_chains.call_args
+        self.assert_iptables_update(
+            args, to_updates, from_updates, to_chain_names, from_chain_names
+        )
+
+    def test_on_endpoint_removed_idempotent(self):
+        """
+        Tests that removing an endpoint multiple times does nothing.
+        """
+        d = self.getDispatchChain()
+
+        # Insert some basic chains.
+        d.apply_snapshot(['tapabcdef', 'tap123456', 'tapa7d849'], async=True)
+        self.step_actor(d)
+
+        # Remove an endpoint.
+        d.on_endpoint_removed('tapabcdef', async=True)
+        self.step_actor(d)
+
+        # Remove it a few more times for good measure.
+        d.on_endpoint_removed('tapabcdef', async=True)
+        self.step_actor(d)
+        d.on_endpoint_removed('tapabcdef', async=True)
+        self.step_actor(d)
+        d.on_endpoint_removed('tapabcdef', async=True)
+        self.step_actor(d)
+
+        # Confirm that we only got called twice.
+        self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)


### PR DESCRIPTION
This is the result of my code review and unit test of the `dispatch.py` module.

This is divided into a number of commits that are well isolated from each other, I recommend reviewing them individually rather than focussing on the diff as a whole.

The first commit pulls some utility functions out of `endpoints.py` into `frules.py`. This prevents an import cycle where `dispatch.py` needed to import `endpoints.py`, which needs to import `dispatch.py`: now both simply import `frules.py`. The functions that got moved were logically part of `frules.py` anyway.

The second commit tidies up `dispatch.py` a little bit: it's small and can easily be verified to have no functional effect. It takes advantage of the first commit to move an inline import up to the top of the module.

The third commit refactors the implementation and interface of `DispatchChains`. This class used a dictionary in its implementation, but never once accessed the values of that dictionary in order to do anything with them. As a result, I pulled that out and replaced it with a set. This obviously changed the interface as well, which no longer wants to deal with dictionaries or dict values, so I had to touch the bits of the code that touched the `DispatchChains` class.

Finally, I wrote UT for the end result.