### PR TITLE
Allow for config to be read from config files.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -21,8 +21,8 @@ felix.config
 Configuration management for Felix.
 
 On instantiation, this module automatically parses the configuration file and
-builds a singleton configuration object. Other modules should just import the
-Config object and use the fields within it.
+builds a singleton configuration object. That object may (once) be changed by
+etcd configuration being reported back to it.
 """
 import os
 
@@ -46,166 +46,299 @@ LOGLEVELS = {"none":      None,
              "crit":      logging.CRITICAL,
              "critical":  logging.CRITICAL}
 
+# Sources of a configuration parameter. The order is highest-priority first.
+DEFAULT = "Default"
+ENV = "Environment variable"
+FILE = "Configuration file"
+GLOBAL_ETCD = "Global etcd configuration"
+LOCAL_ETCD = "Host specific etcd configuration"
+DEFAULT_SOURCES = [ ENV, FILE, GLOBAL_ETCD, LOCAL_ETCD ]
 
 class ConfigException(Exception):
-    def __init__(self, message, source):
+    def __init__(self, message, parameter):
         super(ConfigException, self).__init__(message)
         self.message = message
-        self.source = source
+        self.parameter = parameter
 
     def __str__(self):
-        return "%s (data source : %s)" % (self.message, self.source)
+        return "%s (value %r for %s (%s), read from %r)" \
+            % (self.message,
+               self.parameter.value,
+               self.parameter.name,
+               self.parameter.description,
+               self.parameter.active_source)
+
+class ConfigParameter(object):
+    """
+    A configuration parameter. This contains the following information.
+    - The name of the field.
+    - Where the location can validly be read from
+    - The current value
+    - Where the value was read from
+    """
+    def __init__(self, name, description, default,
+                 sources=DEFAULT_SOURCES, int=False):
+        """
+        Create a configuration parameter.
+        :param str description: Description for logging
+        :param list sources: List of valid sources to try
+        :param str default: Default value
+        :param bool int: Integer value?
+        """
+        self.description = description
+        self.name = name
+        self.sources = sources
+        self.value = default
+        self.active_source = None
+        self.value_is_int = int
+
+    def set(self, value, source):
+        """
+        Set a value of a parameter - unless already set.
+        :param value: value
+        :param source: source; for example "Configuration file /etc/felix.cfg"
+        """
+        if self.active_source is None:
+            log.debug("Read value %r for %s (%s) from %r",
+                      value,
+                      self.name,
+                      self.description,
+                      source)
+
+            self.active_source = source
+
+            if self.value_is_int:
+                self.value = value
+                try:
+                    self.value = int(value)
+                except ValueError:
+                    raise ConfigException("Field was not integer",
+                                          self)
+            else:
+                # Calling str in principle can throw an exception, but it's
+                # hard to see how in practice, so don't catch and wrap.
+                self.value = str(value)
+        else:
+            log.warning("Ignore %r value for %s (%s) - already set from %r",
+                        source,
+                        self.name,
+                        self.description,
+                        self.active_source)
+
 
 class Config(object):
     def __init__(self, config_path):
         """
-        Create a config.
+        Create a config. This reads data from the following sources.
+        - Environment variables
+        - Configuration file
+        - per-host etcd (/calico/vX/config)
+        - global etcd (/calico/vX/host/<host>/config)
         :raises EtcdException
         """
-        self._KnownSections = set()
-        self._KnownObjects  = set()
+        self.parameters = {}
 
-        self._config_path = config_path
-        self._items = {}
+        self.add_parameter("EtcdAddr", "Address and port for etcd",
+                           "localhost:4001", sources = [ENV, FILE])
+        self.add_parameter("FelixHostname", "Felix compute host hostname",
+                           socket.gethostname(), sources = [ENV, FILE])
 
-        self.read_cfg_file(config_path)
+        self.add_parameter("StartupCleanupDelay", "Delay before cleanup starts",
+                           30, int = True)
+        self.add_parameter("MetadataAddr", "Metadata IP address or hostname",
+                           "127.0.0.1")
+        self.add_parameter("MetadataPort", "Metadata Port", 8775, int=True)
+        self.add_parameter("InterfacePrefix", "Interface name prefix", None)
+        self.add_parameter("LogFilePath",
+                           "Path to log file", "/var/log/calico/felix.log")
+        self.add_parameter("LogSeverityFile",
+                           "Log severity for logging to file", "INFO")
+        self.add_parameter("LogSeveritySys",
+                           "Log severity for logging to syslog", "ERROR")
+        self.add_parameter("LogSeverityScreen",
+                           "Log severity for logging to screen", "ERROR")
 
-        self.ETCD_ADDR = self.get_cfg_entry("global", "EtcdAddr",
-                                            "localhost:4001")
+        # Read the environment variables, then the configuration file.
+        self._read_env_vars()
+        self._read_cfg_file(config_path)
+        self._finish_update(final=False)
+
+    def add_parameter(self, name, description, default, **kwargs):
+        """
+        Put a parameter in the parameter dictionary.
+        """
+        self.parameters[name] = ConfigParameter(
+            name, description, default, **kwargs)
+
+    def _finish_update(self, final=False):
+        """
+        Config has been completely read. Called twice - once after reading from
+        environment and config file (so we should be able to access etcd), and
+        once after reading from etcd (so we have all the config ready to go).
+
+        Responsible for :
+        - storing the parameters in the relevant fields in the structure
+        - validating the configuration is valid (for this stage in the process)
+        - updating logging parameters (if this is the final call)
+        :param final: Have we completed (rather than just read env and config file)
+        """
+        self.ETCD_ADDR = self.parameters["EtcdAddr"].value
+        self.HOSTNAME = self.parameters["FelixHostname"].value
+        self.STARTUP_CLEANUP_DELAY = self.parameters["StartupCleanupDelay"].value
+        self.METADATA_IP = self.parameters["MetadataAddr"].value
+        self.METADATA_PORT = self.parameters["MetadataPort"].value
+        self.IFACE_PREFIX = self.parameters["InterfacePrefix"].value
+        self.LOGFILE = self.parameters["LogFilePath"].value
+        self.LOGLEVFILE = self.parameters["LogSeverityFile"].value
+        self.LOGLEVSYS = self.parameters["LogSeveritySys"].value
+        self.LOGLEVSCR = self.parameters["LogSeverityScreen"].value
+
+        self._validate_cfg(final=final)
+
+        if final:
+            # Update logging.
+            common.complete_logging(self.LOGFILE,
+                                    self.LOGLEVFILE,
+                                    self.LOGLEVSYS,
+                                    self.LOGLEVSCR)
+
+            # Log configuration - the whole lot of it.
+            for name, parameter in self.parameters.iteritems():
+                log.info("Parameter %s (%s) has value %r read from %s",
+                         name,
+                         parameter.description,
+                         parameter.value,
+                         parameter.active_source)
+
+    def _read_env_vars(self):
+        """
+        Read all of the variables from the environment.
+        """
+        for name, parameter in self.parameters.iteritems():
+            # All currently defined config parameters have ENV as a valid source.
+            assert(ENV in parameter.sources)
+            # ENV is the first source, so we can assert that using defaults.
+            assert(parameter.active_source is None)
+
+            env_var = ("FELIX_%s" % name).upper()
+            if env_var in os.environ:
+                parameter.set(os.environ[env_var],
+                              "Environment variable %s" % env_var)
+
+    def _read_cfg_file(self, config_file):
+        parser = ConfigParser.ConfigParser()
+        parser.read(config_file)
+        cfg_dict = {}
+
+        # Build up the cfg dictionary from the file.
+        for section in parser.sections():
+            cfg_dict.update(dict(parser.items(section)))
+
+        source = "Configuration file %s" % config_file
+
+        for name, parameter in self.parameters.iteritems():
+            # Config parameters are lower-cased by ConfigParser
+            name = name.lower()
+            if FILE in parameter.sources and name in cfg_dict:
+                # This can validly be read from file.
+                parameter.set(cfg_dict.pop(name), source)
+        self._warn_unused_cfg(cfg_dict, source)
+
+    def report_etcd_config(self, host_dict, global_dict):
+        """
+        Report back configuration parameters read from etcd.
+        :param host_dict: Dictionary of etcd parameters
+        :param global_dict: Dictionary of global parameters
+        :raises ConfigException
+        """
+        log.debug("Configuration reported from etcd")
+        for source in (LOCAL_ETCD, GLOBAL_ETCD):
+            if source == LOCAL_ETCD:
+                cfg_dict = host_dict
+            else:
+                cfg_dict = global_dict
+
+            for name, parameter in self.parameters.iteritems():
+                if source in parameter.sources and name in cfg_dict:
+                    parameter.set(cfg_dict.pop(name), source)
+
+            self._warn_unused_cfg(cfg_dict, source)
+
+        self._finish_update(final=True)
+
+    def _validate_cfg(self, final=True):
+        """
+        Firewall that the config is not invalid.
+        :param stage: Which source we just loaded.
+        :raises ConfigException
+        """
         fields = self.ETCD_ADDR.split(":")
         if len(fields) != 2:
-            raise ConfigException("Invalid format for EtcdAddr (%s) - must be "
-                                  "hostname:port" %
-                                  (self.ETCD_ADDR), self._config_path)
-
-        self.validate_addr("EtcdAddr", fields[0])
+            raise ConfigException("Invalid format for field - must be "
+                                  "hostname:port", self.parameters["EtcdAddr"])
+        self._validate_addr("EtcdAddr", fields[0])
 
         try:
             int(fields[1])
         except ValueError:
-            raise ConfigException("Invalid port in EtcdAddr (%s)" %
-                                  (self.ETCD_ADDR), self._config_path)
+            raise ConfigException("Invalid port in field",
+                                  self.parameters["EtcdAddr"])
 
-        self.HOSTNAME = self.get_cfg_entry("global",
-                                           "FelixHostname",
-                                           socket.gethostname())
+        try:
+            self.LOGLEVFILE = LOGLEVELS[self.LOGLEVFILE.lower()]
+        except KeyError:
+            raise ConfigException("Invalid log level",
+                                  self.parameters["LogSeverityFile"])
 
-        self.STARTUP_CLEANUP_DELAY = 30
-        self.METADATA_IP = "127.0.0.1"
-        self.METADATA_PORT = "8775"
-        self.RESYNC_INT_SEC = 1800
-        self.IFACE_PREFIX = None
-        self.LOGFILE = "/var/log/calico/felix.log"
-        self.LOGLEVFILE = "INFO"
-        self.LOGLEVSYS = "ERROR"
-        self.LOGLEVSCR = "ERROR"
+        try:
+            self.LOGLEVSYS = LOGLEVELS[self.LOGLEVSYS.lower()]
+        except KeyError:
+            raise ConfigException("Invalid log level",
+                                  self.parameters["LogSeveritySys"])
 
-        self.LOGLEVFILE = LOGLEVELS.get(self.LOGLEVFILE.lower(), logging.DEBUG)
-        self.LOGLEVSYS = LOGLEVELS.get(self.LOGLEVSYS.lower(), logging.DEBUG)
-        self.LOGLEVSCR = LOGLEVELS.get(self.LOGLEVSCR.lower(), logging.DEBUG)
+        try:
+            self.LOGLEVSCR = LOGLEVELS[self.LOGLEVSCR.lower()]
+        except KeyError:
+            raise ConfigException("Invalid log level",
+                                  self.parameters["LogSeverityScreen"])
 
-    def update_config(self, cfg_dict):
-        self.STARTUP_CLEANUP_DELAY = int(cfg_dict.pop("StartupCleanupDelay",
-                                                      "30"))
-        self.METADATA_IP = cfg_dict.pop("MetadataAddr", "127.0.0.1")
-        self.METADATA_PORT = cfg_dict.pop("MetadataPort", "8775")
-        self.RESYNC_INT_SEC = int(cfg_dict.pop("ResyncIntervalSecs", "1800"))
-        self.IFACE_PREFIX = cfg_dict.pop("InterfacePrefix", None)
-        self.LOGFILE = cfg_dict.pop("LogFilePath", "/var/log/calico/felix.log")
-        self.LOGLEVFILE = cfg_dict.pop("LogSeverityFile", "INFO")
-        self.LOGLEVSYS = cfg_dict.pop("LogSeveritySys", "ERROR")
-        self.LOGLEVSCR = cfg_dict.pop("LogSeverityScreen", "ERROR")
+        # Log file may be "None" (the literal string, case insensitive). In
+        # this case no log file should be written.
+        if self.LOGFILE.lower() == "none":
+            self.LOGFILE = None
 
-        self.LOGLEVFILE = LOGLEVELS.get(self.LOGLEVFILE.lower(), logging.DEBUG)
-        self.LOGLEVSYS = LOGLEVELS.get(self.LOGLEVSYS.lower(), logging.DEBUG)
-        self.LOGLEVSCR = LOGLEVELS.get(self.LOGLEVSCR.lower(), logging.DEBUG)
-
-        self.validate_cfg()
-
-        self.warn_unused_cfg(cfg_dict)
-
-    def read_cfg_file(self, config_file):
-        self._parser = ConfigParser.ConfigParser()
-        self._parser.read(config_file)
-
-        # Build up the list of sections.
-        for section in self._parser.sections():
-            self._items[section] = dict(self._parser.items(section))
-
-        if not self._items:
-            log.warning("Configuration file %s has no sections",
-                        config_file)
-
-    def get_cfg_entry(self, section, name, default):
-        name = name.lower()
-        section = section.lower()
-
-        # We're assuming that there's only one section for now so we don't
-        # need the section name in the environment variable name.
-        assert section == "global"
-        env_var = ("FELIX_%s" % name).upper()
-        log.debug("Looking for environment variable override %s", env_var)
-        if env_var in os.environ:
-            value = os.environ[env_var]
-            log.info("Environment variable %s=%r overrides config file: %s/%s",
-                     env_var, value, section, name)
-            return value
-
-        if section not in self._items:
-            return default
-
-        item = self._items[section]
-
-        if name in item:
-            value = item[name]
-            del item[name]
-        else:
-            value = default
-
-        return value
-
-    def validate_cfg(self):
-        #*********************************************************************#
-        #* Firewall that the config is not invalid.                          *#
-        #*********************************************************************#
         if self.METADATA_IP.lower() == "none":
             # Metadata is not required.
             self.METADATA_IP = None
             self.METADATA_PORT = None
         else:
             # Metadata must be supplied as IP or address, but we store as IP
-            self.METADATA_IP = self.validate_addr("MetadataAddr",
+            self.METADATA_IP = self._validate_addr("MetadataAddr",
                                                   self.METADATA_IP)
 
             if not common.validate_port(self.METADATA_PORT):
-                raise ConfigException("Invalid MetadataPort value : %s" %
-                                      self.METADATA_PORT,
-                                      "etcd:/calico/config/MetadataPort")
+                raise ConfigException("Invalid field value",
+                                      self.parameters["MetadataPort"])
 
+        if not final:
+            # Do not check that unset parameters are defaulted; we have more
+            # config to read.
+            return
 
-        if self.IFACE_PREFIX is None:
-            raise ConfigException("Missing InterfacePrefix value",
-                                  "etcd:/calico/config/InterfacePrefix")
+        for name, parameter in self.parameters.iteritems():
+            if parameter.value is None:
+                # No value, not even a default
+                raise ConfigException("Missing undefaulted value",
+                                      self.parameters["InterfacePrefix"])
 
-        # Log file may be "None" (the literal string, either provided or as
-        # default). In this case no log file should be written.
-        if self.LOGFILE.lower() == "none":
-            self.LOGFILE = None
-
-    def warn_unused_cfg(self, cfg_dict):
-        # Firewall that no unexpected items in the config file - i.e. ones we
-        # have not used.
-        for section in self._items.keys():
-            for lKey in self._items[section].keys():
-                log.warning("Got unexpected item %s=%s in %s",
-                            lKey, self._items[section][lKey], self._config_path)
-
+    def _warn_unused_cfg(self, cfg_dict, source):
+        # Warn about any unexpected items - i.e. ones we have not used.
         for lKey in cfg_dict:
-            log.warning("Got unexpected etcd config item %s=%s",
+            log.warning("Got unexpected config item %s=%s",
                         lKey, cfg_dict[lKey])
 
 
-    def validate_addr(self, name, addr):
+    def _validate_addr(self, name, addr):
         """
         Validate an address, returning the IP address it resolves to. If the
         address cannot be resolved then an exception is returned.
@@ -217,11 +350,10 @@ class Config(object):
         try:
             stripped_addr = addr.strip()
             if not stripped_addr:
-                raise ConfigException("Blank %s value" % name,
-                                      self._config_path)
+                raise ConfigException("Blank value",
+                                      self.parameters[name])
 
             return socket.gethostbyname(addr)
         except socket.gaierror:
-            raise ConfigException("Invalid or unresolvable %s value : %s" %
-                                  (name, addr),
-                                  self._config_path)
+            raise ConfigException("Invalid or unresolvable value",
+                                  self.parameters[name])

--- a/calico/felix/test/data/felix_section.cfg
+++ b/calico/felix/test/data/felix_section.cfg
@@ -1,0 +1,11 @@
+[global]
+LogFilePath = /log/nowhere.log
+
+[log]
+MetadataAddr = 1.2.3.4
+
+[whatever]
+MetadataPort = 246
+
+[log]
+InterfacePrefix = whatever

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -35,12 +35,6 @@ else:
 log = logging.getLogger(__name__)
 
 class TestConfig(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_default_config(self):
         """
         Test various ways of defaulting config.

--- a/calico/felix/test/test_config.py
+++ b/calico/felix/test/test_config.py
@@ -20,60 +20,26 @@ Top level tests for Felix configuration.
 """
 
 from collections import namedtuple
-import etcd
 import logging
-from mock import patch
+import mock
 import socket
 import sys
 from calico.felix.config import Config, ConfigException
-from calico.felix.fetcd import EtcdWatcher
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
 
-real_client = etcd.client
-
 # Logger
 log = logging.getLogger(__name__)
 
-# Set of results from etcd.
-etcd_results = {}
-
-EtcdChild = namedtuple('EtcdChild', ['key', 'value'])
-
-class StubEtcdResult(object):
-    def __init__(self, path):
-        self.children = []
-        self.path = path
-        etcd_results[path] = self
-
-    def add_child(self, key, value):
-        key = "%s/%s" % (self.path, key)
-        self.children.append(EtcdChild(key, value))
-
-class StubEtcd(object):
-    """
-    Trivial etcd stub.
-    """
-    def __init__(self, host=None, port=None):
-        self.host = host
-        self.port = port
-
-    def read(self, path, timeout=None):
-        return etcd_results[path]
-
-
 class TestConfig(unittest.TestCase):
     def setUp(self):
-        # Stub out etcd.
-        etcd.Client = StubEtcd
-        etcd_results.clear()
+        pass
 
     def tearDown(self):
-        # Unstub etcd.
-        etcd.Client = real_client
+        pass
 
     def test_default_config(self):
         """
@@ -86,30 +52,27 @@ class TestConfig(unittest.TestCase):
                   ]
 
         for filename in files:
-            host = socket.gethostname()
-            host_path = "/calico/host/%s/config/" % host
-
-
             config = Config("calico/felix/test/data/%s" % filename)
-            cfg_dict = { "InterfacePrefix": "blah",
-                         "ExtraJunk": "whatever", #ignored
-                         "ResyncIntervalSecs": "123" }
-            config.update_config(cfg_dict)
+            host_dict = { "InterfacePrefix": "blah",
+                          "MetadataPort": 123 }
+            global_dict = { "InterfacePrefix": "overridden",
+                            "MetadataAddr": "1.2.3.4" }
+            with mock.patch('calico.common.complete_logging'):
+                config.report_etcd_config(host_dict, global_dict)
 
             # Test defaulting.
             self.assertEqual(config.ETCD_ADDR, "localhost:4001")
-            self.assertEqual(config.HOSTNAME, host)
+            self.assertEqual(config.HOSTNAME, socket.gethostname())
             self.assertEqual(config.IFACE_PREFIX, "blah")
-            self.assertEqual(config.RESYNC_INT_SEC, 123)
+            self.assertEqual(config.METADATA_PORT, 123)
+            self.assertEqual(config.METADATA_IP, "1.2.3.4")
 
     def test_invalid_port(self):
-
-        data = { "felix_invalid_port.cfg": "Invalid port in EtcdAddr",
-                 "felix_invalid_addr.cfg": "Invalid or unresolvable EtcdAddr",
-                 "felix_invalid_both.cfg": "Invalid or unresolvable EtcdAddr",
-                 "felix_invalid_format.cfg": "Invalid format for EtcdAddr"
+        data = { "felix_invalid_port.cfg": "Invalid port in field",
+                 "felix_invalid_addr.cfg": "Invalid or unresolvable",
+                 "felix_invalid_both.cfg": "Invalid or unresolvable",
+                 "felix_invalid_format.cfg": "Invalid format for field"
         }
-
 
         for filename in data:
             log.debug("Test filename : %s", filename)
@@ -119,114 +82,125 @@ class TestConfig(unittest.TestCase):
 
     def test_no_logfile(self):
         # Logging to file can be excluded by explicitly saying "none"
-        host = socket.gethostname()
-        host_path = "/calico/host/%s/config/" % host
-
-        result = StubEtcdResult("/calico/config/")
-        result.add_child("InterfacePrefix", "blah")
-        result.add_child("LogFilePath", "NoNe")
-
-        result = StubEtcdResult(host_path)
-
         config = Config("calico/felix/test/data/felix_missing.cfg")
         cfg_dict = { "InterfacePrefix": "blah",
-                     "LogFilePath": "None",
-                     "ResyncIntervalSecs": "123" }
-        config.update_config(cfg_dict)
+                     "LogFilePath": "None" }
+        with mock.patch('calico.common.complete_logging'):
+            config.report_etcd_config({}, cfg_dict)
 
         self.assertEqual(config.LOGFILE, None)
 
-    def xtest_no_metadata(self):
+    def test_no_metadata(self):
         # Metadata can be excluded by explicitly saying "none"
-        host = socket.gethostname()
-        host_path = "/calico/host/%s/config/" % host
-
-        result = StubEtcdResult("/calico/config/")
-        result.add_child("InterfacePrefix", "blah")
-        result.add_child("MetadataAddr", "NoNe")
-        result.add_child("MetadataPort", "123")
-
-        result = StubEtcdResult(host_path)
-
         config = Config("calico/felix/test/data/felix_missing.cfg")
-        etcd_watcher = EtcdWatcher(config)
-        result = etcd_watcher.load_config(async=True)
-        result.get()
+
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "MetadataAddr": "NoNe",
+                     "MetadataPort": 123 }
+        with mock.patch('calico.common.complete_logging'):
+            config.report_etcd_config({}, cfg_dict)
 
         # Test defaulting.
         self.assertEqual(config.METADATA_IP, None)
         self.assertEqual(config.METADATA_PORT, None)
 
-    def xtest_bad_metadata_port(self):
-        with self.assertRaisesRegexp(ConfigException, "Invalid MetadataPort"):
-            host = socket.gethostname()
-            host_path = "/calico/host/%s/config/" % host
-
-            result = StubEtcdResult("/calico/config/")
-            result.add_child("InterfacePrefix", "blah")
-            result.add_child("MetadataPort", "bloop")
-
-            result = StubEtcdResult(host_path)
-
-            config = Config("calico/felix/test/data/felix_missing.cfg")
-            etcd_watcher = EtcdWatcher(config)
-            result = etcd_watcher.load_config(async=True)
-            result.get()
-
-    def xtest_bad_metadata_addr(self):
+    def test_metadata_port_not_int(self):
+        config = Config("calico/felix/test/data/felix_missing.cfg")
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "MetadataAddr": "127.0.0.1",
+                     "MetadataPort": "bloop" }
         with self.assertRaisesRegexp(ConfigException,
-                                     "Invalid or unresolvable MetadataAddr"):
-            host = socket.gethostname()
-            host_path = "/calico/host/%s/config/" % host
+                                     "Field was not integer.*MetadataPort"):
+            config.report_etcd_config({}, cfg_dict)
 
-            result = StubEtcdResult("/calico/config/")
-            result.add_child("InterfacePrefix", "blah")
-            result.add_child("MetadataAddr", "bloop")
-
-            result = StubEtcdResult(host_path)
-
+    def test_metadata_port_not_valid_1(self):
+        for i in (0, -1, 99999):
+            log.debug("Test invalid metadata port %d", i)
             config = Config("calico/felix/test/data/felix_missing.cfg")
-            etcd_watcher = EtcdWatcher(config)
-            result = etcd_watcher.load_config(async=True)
-            result.get()
+            cfg_dict = { "InterfacePrefix": "blah",
+                         "MetadataAddr": "127.0.0.1",
+                         "MetadataPort": i }
+            with self.assertRaisesRegexp(ConfigException,
+                                         "Invalid field value.*MetadataPort"):
+                config.report_etcd_config({}, cfg_dict)
 
-    def xtest_blank_metadata_addr(self):
+    def test_bad_metadata_addr(self):
+        config = Config("calico/felix/test/data/felix_missing.cfg")
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "MetadataAddr": "bloop",
+                     "MetadataPort": "123" }
         with self.assertRaisesRegexp(ConfigException,
-                                     "Blank MetadataAddr value"):
-            host = socket.gethostname()
-            host_path = "/calico/host/%s/config/" % host
+                                     "Invalid or unresolvable.*MetadataAddr"):
+            config.report_etcd_config({}, cfg_dict)
 
-            result = StubEtcdResult("/calico/config/")
-            result.add_child("InterfacePrefix", "blah")
-            result.add_child("MetadataAddr", "")
-
-            result = StubEtcdResult(host_path)
-
+    def test_bad_log_level(self):
+        for field in ("LogSeverityFile", "LogSeverityScreen", "LogSeveritySys"):
             config = Config("calico/felix/test/data/felix_missing.cfg")
-            etcd_watcher = EtcdWatcher(config)
-            result = etcd_watcher.load_config(async=True)
-            result.get()
 
+            cfg_dict = { "LogInterfacePrefix": "blah",
+                         field: "bloop" }
+            with self.assertRaisesRegexp(ConfigException,
+                                         "Invalid log level.*%s" % field):
+                config.report_etcd_config({}, cfg_dict)
 
-    def xtest_no_iface_prefix(self):
-        with self.assertRaisesRegexp(ConfigException, "Missing InterfacePrefix"):
-            host = socket.gethostname()
-            host_path = "/calico/host/%s/config/" % host
+    def test_blank_metadata_addr(self):
+        config = Config("calico/felix/test/data/felix_missing.cfg")
+        cfg_dict = { "InterfacePrefix": "blah",
+                     "MetadataAddr": "",
+                     "MetadataPort": "123" }
+        with self.assertRaisesRegexp(ConfigException,
+                                     "Blank value.*MetadataAddr"):
+            config.report_etcd_config({}, cfg_dict)
 
-            result = StubEtcdResult("/calico/config/")
-            result = StubEtcdResult(host_path)
+    def test_no_iface_prefix(self):
+        config = Config("calico/felix/test/data/felix_missing.cfg")
+        cfg_dict = {}
+        with self.assertRaisesRegexp(ConfigException,
+                        "Missing undefaulted value.*InterfacePrefix"):
+            config.report_etcd_config({}, cfg_dict)
 
-            config = Config("calico/felix/test/data/felix_missing.cfg")
-            etcd_watcher = EtcdWatcher(config)
-            result = etcd_watcher.load_config(async=True)
-            result.get()
+    def test_file_sections(self):
+        """
+        Test various ways of defaulting config.
+        """
+        files = [ "felix_section.cfg", # lots of sections
+                  ]
 
+        for filename in files:
+            config = Config("calico/felix/test/data/%s" % filename)
 
-    @patch("ConfigParser.ConfigParser", autospec=True)
-    def xtest_env_var_override(self, m_ConfigParser):
+            # Test that read ignoring sections.
+            self.assertEqual(config.ETCD_ADDR, "localhost:4001")
+            self.assertEqual(config.HOSTNAME, socket.gethostname())
+            self.assertEqual(config.LOGFILE, "/log/nowhere.log")
+            self.assertEqual(config.IFACE_PREFIX, "whatever")
+            self.assertEqual(config.METADATA_PORT, 246)
+            self.assertEqual(config.METADATA_IP, "1.2.3.4")
+
+    def test_env_var_override(self):
         """
         Test environment variables override config options,
         """
-        with patch.dict("os.environ", {"FELIX_ETCDADDR": "testhost:1234"}):
-            cfg = config.Config("/tmp/felix.cfg")
-        self.assertEqual(cfg.ETCD_ADDR, "testhost:1234")
+        with mock.patch.dict("os.environ", {"FELIX_ETCDADDR": "9.9.9.9:1234",
+                                            "FELIX_METADATAPORT": "999"}):
+            config = Config("calico/felix/test/data/felix_section.cfg")
+
+        host_dict = { "InterfacePrefix": "blah",
+                      "StartupCleanupDelay": "42",
+                      "MetadataAddr": "4.3.2.1",
+                      "MetadataPort": "123" }
+
+        global_dict = { "InterfacePrefix": "blah",
+                        "StartupCleanupDelay": "99",
+                        "MetadataAddr": "5.4.3.2",
+                        "MetadataPort": "123" }
+        with mock.patch('calico.common.complete_logging'):
+            config.report_etcd_config(host_dict, global_dict)
+
+        self.assertEqual(config.ETCD_ADDR, "9.9.9.9:1234")
+        self.assertEqual(config.HOSTNAME, socket.gethostname())
+        self.assertEqual(config.LOGFILE, "/log/nowhere.log")
+        self.assertEqual(config.IFACE_PREFIX, "whatever")
+        self.assertEqual(config.METADATA_PORT, 999)
+        self.assertEqual(config.METADATA_IP, "1.2.3.4")
+        self.assertEqual(config.STARTUP_CLEANUP_DELAY, 42)


### PR DESCRIPTION
Logic is to take config from environment variables, config files, etcd per-host config, etcd global config in that order.

Resolves issue #407.