### PR TITLE
Code review and tests for UpdateSplitter

### DIFF
--- a/calico/felix/splitter.py
+++ b/calico/felix/splitter.py
@@ -28,6 +28,10 @@ _log = logging.getLogger(__name__)
 
 
 class UpdateSplitter(Actor):
+    """
+    Actor that takes the role of message broker, farming updates out to IPv4
+    and IPv6-specific actors.
+    """
     def __init__(self, config, ipsets_mgrs, rules_managers, endpoint_managers,
                  iptables_updaters):
         super(UpdateSplitter, self).__init__()
@@ -44,6 +48,12 @@ class UpdateSplitter(Actor):
         """
         Replaces the whole cache state with the input.  Applies deltas vs the
         current active state.
+
+        :param rules_by_prof_id: A mapping of security profile ID to profile
+            rules.
+        :param tags_by_prof_id: A mapping of security profile ID to profile
+            tags.
+        :param endpoints_by_id: A mapping of endpoint ID to endpoint data.
         """
         # Step 1: fire in data update events to the profile and tag managers
         # so they can build their indexes before we activate anything.
@@ -123,6 +133,9 @@ class UpdateSplitter(Actor):
 
     @actor_message()
     def on_interface_update(self, name):
+        """
+        Called when an interface state has changed.
+        """
         _log.info("Interface %s state changed", name)
         for endpoint_mgr in self.endpoint_mgrs:
             endpoint_mgr.on_interface_update(name, async=True)

--- a/calico/felix/splitter.py
+++ b/calico/felix/splitter.py
@@ -49,11 +49,11 @@ class UpdateSplitter(Actor):
         Replaces the whole cache state with the input.  Applies deltas vs the
         current active state.
 
-        :param rules_by_prof_id: A mapping of security profile ID to profile
-            rules.
-        :param tags_by_prof_id: A mapping of security profile ID to profile
-            tags.
-        :param endpoints_by_id: A mapping of endpoint ID to endpoint data.
+        :param rules_by_prof_id: A dict mapping security profile ID to a list
+            of profile rules, each of which is a dict.
+        :param tags_by_prof_id: A dict mapping security profile ID to a list of
+            profile tags.
+        :param endpoints_by_id: A dict mapping endpoint ID to endpoint data.
         """
         # Step 1: fire in data update events to the profile and tag managers
         # so they can build their indexes before we activate anything.

--- a/calico/felix/test/test_splitter.py
+++ b/calico/felix/test/test_splitter.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014, 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+felix.test.test_splitter
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests of the actor that splits update messages to multiple manager actors.
+"""
+import collections
+
+import gevent
+import mock
+
+from calico.felix.test.base import BaseTestCase
+from calico.felix.splitter import UpdateSplitter
+
+
+# A mocked config object for use in the UpdateSplitter.
+Config = collections.namedtuple('Config', ['STARTUP_CLEANUP_DELAY'])
+
+class TestUpdateSplitter(BaseTestCase):
+    """
+    Tests for the UpdateSplitter actor.
+    """
+    def setUp(self):
+        super(TestUpdateSplitter, self).setUp()
+
+        # Set the cleanup delay to 0, to force immediate cleanup.
+        self.config = Config(0)
+        self.ipsets_mgrs = [mock.MagicMock(), mock.MagicMock()]
+        self.rules_mgrs = [mock.MagicMock(), mock.MagicMock()]
+        self.endpoint_mgrs = [mock.MagicMock(), mock.MagicMock()]
+        self.iptables_updaters = [mock.MagicMock(), mock.MagicMock()]
+
+    def get_splitter(self):
+        return UpdateSplitter(
+            self.config,
+            self.ipsets_mgrs,
+            self.rules_mgrs,
+            self.endpoint_mgrs,
+            self.iptables_updaters,
+        )
+
+    def test_apply_whole_snapshot_clean(self):
+        """
+        Test that a whole snapshot applies cleanly to all managers.
+        """
+        # We apply a simple sentinel map. The exact map we use really shouldn't
+        # matter here. We do, however, use different ones for rules, tags, and
+        # endpoints.
+        rules = {'profileA': ['first rule', 'second rule']}
+        tags = {'profileA': ['first tag', 'second tag']}
+        endpoints = {'endpointA': 'endpoint object'}
+        s = self.get_splitter()
+
+        # Apply the snapshot and let it run.
+        s.apply_snapshot(rules, tags, endpoints, async=True)
+        self.step_actor(s)
+
+        # At this point, each of our managers should have been notified (one
+        # call to apply_snapshot), but cleanup should not have occurred.
+        for mgr in self.ipsets_mgrs:
+            mgr.apply_snapshot.assertCalledOnceWith(
+                tags, endpoints, async=True
+            )
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.rules_mgrs:
+            mgr.apply_snapshot.assertCalledOnceWith(rules, async=True)
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.endpoint_mgrs:
+            mgr.apply_snapshot.assertCalledOnceWith(endpoints, async=True)
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.iptables_updaters:
+            self.assertEqual(mgr.cleanup.call_count, 0)
+
+        # If we spin the scheduler again, we should begin cleanup.
+        # Warning: this might be a bit brittle, we may not be waiting long
+        # enough here, at least on busy machines.
+        gevent.sleep(0.1)
+        self.step_actor(s)
+
+        # Confirm that we cleaned up. Cleanup only affects the
+        # iptables_updaters and the ipsets_managers, so confirm the other
+        # managers got left alone.
+        for mgr in self.ipsets_mgrs:
+            mgr.cleanup.assertCalledOnceWith(async=False)
+        for mgr in self.rules_mgrs:
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.endpoint_mgrs:
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.iptables_updaters:
+            mgr.cleanup.assertCalledOnceWith(async=False)
+
+    def test_repeated_snapshots_clean_up_only_once(self):
+        """
+        Test that repeated snapshots only clean up once.
+        """
+        # We apply a simple sentinel map. The exact map we use really shouldn't
+        # matter here. We do, however, use different ones for rules, tags, and
+        # endpoints.
+        rules = {'profileA': ['first rule', 'second rule']}
+        tags = {'profileA': ['first tag', 'second tag']}
+        endpoints = {'endpointA': 'endpoint object'}
+        s = self.get_splitter()
+
+        # Apply three snapshots and let them run. Because of batching logic,
+        # we should only need to spin the actor once.
+        s.apply_snapshot(rules, tags, endpoints, async=True)
+        s.apply_snapshot(rules, tags, endpoints, async=True)
+        s.apply_snapshot(rules, tags, endpoints, async=True)
+        self.step_actor(s)
+
+        # At this point, each of our managers should have been notified (one
+        # call to apply_snapshot), but cleanup should not have occurred.
+        for mgr in self.ipsets_mgrs:
+            mgr.apply_snapshot.assertCalledWith(
+                tags, endpoints, async=True
+            )
+            self.assertEqual(mgr.apply_snapshot.call_count, 3)
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.rules_mgrs:
+            mgr.apply_snapshot.assertCalledWith(rules, async=True)
+            self.assertEqual(mgr.apply_snapshot.call_count, 3)
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.endpoint_mgrs:
+            mgr.apply_snapshot.assertCalledWith(endpoints, async=True)
+            self.assertEqual(mgr.apply_snapshot.call_count, 3)
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.iptables_updaters:
+            self.assertEqual(mgr.cleanup.call_count, 0)
+
+        # If we spin the scheduler again, we should begin cleanup.
+        # Warning: this might be a bit brittle, we may not be waiting long
+        # enough here, at least on busy machines.
+        gevent.sleep(0.1)
+        self.step_actor(s)
+
+        # Confirm that we cleaned up. Cleanup only affects the
+        # iptables_updaters and the ipsets_managagers, so confirm the other
+        # managers got left alone.
+        for mgr in self.ipsets_mgrs:
+            mgr.cleanup.assertCalledOnceWith(async=False)
+        for mgr in self.rules_mgrs:
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.endpoint_mgrs:
+            self.assertEqual(mgr.cleanup.call_count, 0)
+        for mgr in self.iptables_updaters:
+            mgr.cleanup.assertCalledOnceWith(async=False)
+
+    def test_cleanup_aborts_on_exception(self):
+        """
+        Test that cleanup stops processing a given manager type on exception,
+        but that exception in one manager type does not affect the other.
+        """
+        # No need to apply any data here.
+        s = self.get_splitter()
+
+        # However, make sure that the first ipset manager and the first
+        # iptables updater throw exceptions when called.
+        self.ipsets_mgrs[0].cleanup.side_effect = RuntimeError('Bang!')
+        self.iptables_updaters[0].cleanup.side_effect = RuntimeError('Bang!')
+
+        # Start the cleanup.
+        s.trigger_cleanup(async=True)
+        self.step_actor(s)
+
+        # Confirm that we cleaned up. Cleanup only affects the
+        # iptables_updaters and the ipsets_managagers, so confirm the other
+        # managers got left alone.
+        self.ipsets_mgrs[0].cleanup.assertCalledOnceWith(async=False)
+        self.assertEqual(self.ipsets_mgrs[1].cleanup.call_count, 0)
+        self.iptables_updaters[0].cleanup.assertCalledOnceWith(async=False)
+        self.assertEqual(self.iptables_updaters[1].cleanup.call_count, 0)
+
+    def test_rule_updates_propagate(self):
+        """
+        Test that the on_rules_update message propagates correctly.
+        """
+        s = self.get_splitter()
+        profile = 'profileA'
+        rules = ['first rule', 'second rule']
+
+        # Apply the rules update
+        s.on_rules_update(profile, rules, async=True)
+        self.step_actor(s)
+
+        # Confirm that the rules update propagates.
+        for mgr in self.rules_mgrs:
+            mgr.on_rules_update.assertCalledOnceWith(
+                profile, rules, async=True
+            )
+
+    def test_tags_updates_propagate(self):
+        """
+        Test that the on_tags_update message propagates correctly.
+        """
+        s = self.get_splitter()
+        profile = 'profileA'
+        tags = ['first tag', 'second tag']
+
+        # Apply the tags update
+        s.on_tags_update(profile, tags, async=True)
+        self.step_actor(s)
+
+        # Confirm that the rules update propagates.
+        for mgr in self.ipsets_mgrs:
+            mgr.on_tags_update.assertCalledOnceWith(
+                profile, tags, async=True
+            )
+
+    def test_interface_updates_propagate(self):
+        """
+        Test that the on_interface_update message propagates correctly.
+        """
+        s = self.get_splitter()
+        interface = 'tapABCDEF'
+
+        # Apply the interface update
+        s.on_interface_update(interface, async=True)
+        self.step_actor(s)
+
+        # Confirm that the interface update propagates.
+        for mgr in self.endpoint_mgrs:
+            mgr.on_interface_update.assertCalledOnceWith(interface, async=True)
+
+    def test_endpoint_updates_propagate(self):
+        """
+        Test that the on_endpoint_update message propagates correctly.
+        """
+        s = self.get_splitter()
+        endpoint = 'endpointA'
+        endpoint_object = 'endpoint'
+
+        # Apply the endpoint update
+        s.on_endpoint_update(endpoint, endpoint_object, async=True)
+        self.step_actor(s)
+
+        # Confirm that the endpoint update propagates.
+        for mgr in self.ipsets_mgrs:
+            mgr.on_endpoint_update.assertCalledOnceWith(
+                endpoint, endpoint_object, async=True
+            )
+        for mgr in self.endpoint_mgrs:
+            mgr.on_endpoint_update.assertCalledOnceWith(
+                endpoint, endpoint_object, async=True
+            )


### PR DESCRIPTION
This pull request contains minor review markups (docstrings only) and unit tests for the `UpdateSplitter`.

Before merging this, I have more substantive review feedback (/cc @fasaxc) that should be considered.

The `UpdateSplitter` class knows way too much about the objects it contains. At its core, this class is nothing more than a message broker: given a message A, it routes it to all actors that handle message A. The problem is that it doesn't ask actors whether they can handle message A, it knows which actors can do it and what arguments they take.

This limits this class quite severely, and also manages to inflate the number of lines of code in the class. For example, right now there are four `on_*_update` methods on the class. Each method does nothing more than call the equivalently named method on the managers that have that method. There is no earthly reason that all four methods could not be replaced by a little bit of magic:

```python
def __getattr__(self, name):
    def proxy_function(self, *args, **kwargs):
        for manager in self.managers:
            if hasattr(manager, name):
                getattr(manager, name)(*args, **kwargs, async=True)

    setattr(self, name) = proxy_function
```

The only reason I can think of not to do this is because it harms introspection, but that's ok, because you can always replace them with simple wrapper methods that call `self._proxy_function` instead. Hell, you could even use a decorator if you wanted.

There are other patterns you could use: managers could register method names they want to handle with the UpdateSplitter, for example, which is more explicit but slightly more verbose. Or the code that creates the UpdateSplitter could do so. Or we could require that managers have a parameter that names all the messages they want to receive.

Any of these changes make this class substantially more general, which makes it more robust in the face of extension and re-use. Switching to this general architecture makes this class usable in many other roles.

The only hiccup in this plan is `apply_snapshot`. This is because each manager takes *different* arguments to its `apply_snapshot` method. This is nuts: it forces the UpdateSplitter to know about the arguments each actor needs to take, for no good reason. Each manager should be updated to have the exact same message signature for `apply_snapshot`, and it should simply ignore anything it doesn't need.

That leaves us with the other wart: cleanup. There are two problems here. The first is that cleanup, as written, works weirdly (and probably incorrectly). The second is that it's not clear that cleanup has a good design. I'll handle them in that order.

First, cleanup works weirdly. The cleanup process stops for a given type of manager when any manager of that type throws an exception. Why does an exception in the ip4tables manager prevent us cleaning up ip6tables? That feels wrong, and should be changed, unless there's something I'm not seeing.

The follow-on is that the whole architecture is odd. We schedule cleanup for ~30 seconds after a snapshot is applied. This is *obviously* racy: so obvious, in fact, that the comment above this block outright says so, and waves away concerns about dropping packets.

This feels crazy. If we want to cleanup, we should do it properly. Each manager should be capable of taking a cleanup message and acting on it, or it should automatically clean up after itself. Why can managers not clean up automatically after snapshots are applied? Ordering appears to be the concern here (we need to clean up iptables before ipsets), but again it feels like managers should be making repeated attempts to delete anything they fail to delete the first time *anyway*.

I think cleanup needs much more thought applied to it before we call ourselves happy.

For the moment, I see no reason not to merge these tests and markups: they've been written anyway, and they won't slow us down much if we rewrite this module. Nevertheless, we should think hard about the design here.