### PR TITLE
NEEDS FV Replace endpoint ID with tuple that includes host and workload too.

### DIFF
--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -24,6 +24,7 @@ made in a new copy of the file with revved version suffix.  That allows
 us to maintain multiple copies of the data model in parallel during
 migrations.
 """
+from collections import namedtuple
 import logging
 import re
 
@@ -54,7 +55,11 @@ TAGS_KEY_RE = re.compile(
 # Regex to match endpoints, captures "hostname" and "endpoint_id".
 ENDPOINT_KEY_RE = re.compile(
     r'^' + HOST_DIR +
-    r'/(?P<hostname>[^/]+)/.+/endpoint/(?P<endpoint_id>[^/]+)')
+    r'/(?P<hostname>[^/]+)/'
+    r'workload/'
+    r'(?P<orchestrator>[^/]+)/'
+    r'(?P<workload_id>[^/]+)/'
+    r'endpoint/(?P<endpoint_id>[^/]+)')
 
 
 def dir_for_host(hostname):
@@ -96,3 +101,9 @@ def get_profile_id_for_profile_dir(key):
         return None
     prefix, final_node = key.rsplit("/", 1)
     return final_node if prefix == PROFILE_DIR else None
+
+
+class EndpointId(namedtuple("EndpointId", ["host", "orchestrator",
+                                           "workload", "endpoint"])):
+    def __str__(self):
+        return self.__class__.__name__ + ("<%s/%s/%s/%s>" % self)

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -126,8 +126,8 @@ class IpsetManager(ReferenceManager):
             self.on_endpoint_update(endpoint_id, endpoint)
             missing_endpoints.discard(endpoint_id)
             self._maybe_yield()
-        for ep_id in missing_endpoints:
-            self.on_endpoint_update(ep_id, None)
+        for endpoint_id in missing_endpoints:
+            self.on_endpoint_update(endpoint_id, None)
             self._maybe_yield()
 
         _log.info("Tags snapshot applied: %s tags, %s endpoints",
@@ -217,7 +217,7 @@ class IpsetManager(ReferenceManager):
         """
         Update tag memberships and indices with the new endpoint dict.
 
-        :param str endpoint_id: ID of the endpoint.
+        :param EndpointId endpoint_id: ID of the endpoint.
         :param dict|NoneType endpoint: Either a dict containing endpoint
             information or None to indicate deletion.
 


### PR DESCRIPTION
@matthewdupre this addresses the code review comment about not needing to track non-local endpoints in the EndpointManager.  (I needed to pass in the hostname to handle deletes but doing it this way fixes #439 too.)

Removes assumption that endpoint_id is globally unique, which doesn't hold during a VM migration.

Lays the groundwork for handling host and workload deletion without a resync.  (This needs further work.)