### PR TITLE
doc: explain why someone would want to switch to an IP fabric

### DIFF
--- a/docs/source/l3-interconnectFabric.rst
+++ b/docs/source/l3-interconnectFabric.rst
@@ -519,7 +519,16 @@ installation that uses an IP fabric will be limited to the routing table
 size of its constituent network hardware, with a reasonable upper limit
 today of 128,000 endpoints.
 
+On the other hand, with an Ethernet frabric, all your vRouters have to
+handle the endpoints for the whole network (both in BGP and in the
+kernel). Switching to an IP fabric allows you to shift the burden to
+the North: if your spine is part of the IP fabric, each vRouter may
+just learn the routes to other endpoints in the rack. Only the spine
+has to know all endpoints and, as there are fewer of them, it may be
+less expensive to scale them appropriately.
 
+An IP fabric also enables some scenarios difficult to implement with
+an Ethernet fabric like anycast IP.
 
 .. [#endpoints]
    In Calico's terminology, an endpoint is an IP address and interface.


### PR DESCRIPTION
The current recommandation is to use an Ethernet fabric. The
documentation explains what are the limitations of an IP
fabric (commodity switches have to learn many routes and they may not be
able too) but doesn't highlight the limitations of an Ethernet fabric.

This commit adds a paragraph explaining why someone would want to use an
IP fabric. At some point, the vrouters may not scale. I am unsure if
Linux would be able to handle thousands of routes in the kernel
efficiently, so I don't stress too much on this but I mention it. Each
time you scale your network, all vrouters are also using more
CPU/memory. So, the main advantage of an IP fabric is that you can buy a
couple of high end routers as a spine and let the vRouters and the ToR
switches only learn local IP addresses. I am also adding a sentence
about anycasting which is a cool feature coming with an IP fabric. I've
stayed clear of Ethernet downsides as they are solved in the Ethernet
fabric by using seperate planes.