### PR TITLE
AP add docker to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ type:
 
     pip install -e .
 
-This will install the code and all its dependencies, *except for Neutron*. This
+This will install the code and all its dependencies, *except for Neutron or Docker dependencies*. This
 is all you need to work on Felix. If you want to work on our OpenStack plugin,
 you'll also need to install Neutron: doing that is outside the scope of this
-article.
+article.  If you want to work on Docker integration please see the [calico-docker](https://github.com/Metaswitch/calico-docker) repo.
 
 To run the unit tests, you'll also need to type:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ environments.
 ## What does Calico do?
 
 Calico integrates seamlessly with the cloud orchestration system (such as
-OpenStack) to enable secure IP communication between virtual machines. As VMs
+OpenStack) to enable secure IP communication between virtual machines or containers. As VMs or containers
 are created or destroyed, their IP addresses are advertised to the rest of the
 network and they are able to send/receive data over IP just as they would with
 the native networking implementation – but with higher
@@ -34,9 +34,7 @@ the native networking implementation – but with higher
 
 To get started on
 [OpenStack](http://www.openstack.org/) follow the instructions
-[here](http://docs.projectcalico.org/en/latest/openstack.html).
-
-To get started on
+[here](http://docs.projectcalico.org/en/latest/openstack.html). To get started on
 [Docker](http://www.docker.com/) follow the instructions
 [here](https://github.com/Metaswitch/calico-docker/blob/master/README.md).
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ the native networking implementation – but with higher
 
 ## How do I get started with Project Calico?
 
-To get started, you first need a working installation of
-[OpenStack](http://www.openstack.org/). Then download and install the latest
-stable build of Calico following the instructions
+To get started on
+[OpenStack](http://www.openstack.org/) follow the instructions
 [here](http://docs.projectcalico.org/en/latest/openstack.html).
+
+To get started on
+[Docker](http://www.docker.com/) follow the instructions
+[here](https://github.com/Metaswitch/calico-docker/blob/master/README.md).
 
 Technical documentation is [here](http://docs.projectcalico.org/). For
 information about contributing to Calico itself, see the section titled


### PR DESCRIPTION
If you start at projectcalico.org and click on "View on GitHub" (one of the 3 top level call to actions on the landing page) you end up at calico/readme.md which currently has no mention of Docker at all.  This commit adds some links for Docker alongside those for OpenStack.