### PR TITLE
Fix plugin threading

### DIFF
--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -29,6 +29,7 @@ import traceback
 sys.modules['etcd'] = m_etcd = mock.Mock()
 sys.modules['neutron'] = m_neutron = mock.Mock()
 sys.modules['neutron.common'] = m_neutron.common
+sys.modules['neutron.common.exceptions'] = m_neutron.common.exceptions
 sys.modules['neutron.openstack'] = m_neutron.openstack
 sys.modules['neutron.openstack.common'] = m_neutron.openstack.common
 sys.modules['neutron.plugins'] = m_neutron.plugins

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps =
     mock
     coverage>=4.0a5
     unittest2
-    git+http://github.com/Metaswitch/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
+    git+https://github.com/Metaswitch/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
 commands=nosetests --with-coverage


### PR DESCRIPTION
* Cory's retry fix in case we race between SG arrival and endpoint arrival.  (I think this may have been a red herring, I can't seem to hit that case now I have the other fixes in place.)
* The periodic resync thread was clobbering the `needed_profiles` and `sgs` fields on the transport.  I believe the assumption was that this was safe due to eventlet's co-op threading model but that's not true when we're doing IO to access etcd.  We should rework more substantially but I think this fix is correct (if not particularly architectural!)
* There was a race between loading the list of ports in an SG and a port being deleted, catch the PortNotFound exception and treat as if that port wasn't in the SG.