### PR TITLE
Clean up empty etcd directories, handle that in felix

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -475,8 +475,8 @@ class EtcdWatcher(Actor):
 
     def on_workload_delete(self, response, hostname, orchestrator,
                            workload_id):
-        _log.info("Workload dir %s/%s/%s deleted, removing contained hosts",
-                  hostname, orchestrator, workload_id)
+        _log.debug("Workload dir %s/%s/%s deleted, removing endpoints",
+                   hostname, orchestrator, workload_id)
         for endpoint_id in list(self.endpoint_ids_per_host[hostname]):
             if (endpoint_id.orchestrator == orchestrator and
                     endpoint_id.workload == workload_id):

--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -18,6 +18,7 @@ felix.fetcd
 
 Etcd polling functions.
 """
+from collections import defaultdict
 from socket import timeout as SocketTimeout
 from etcd import (EtcdException, EtcdClusterIdChanged, EtcdKeyNotFound,
                   EtcdEventIndexCleared)
@@ -31,11 +32,10 @@ import urllib3.exceptions
 from urllib3.exceptions import ReadTimeoutError, ConnectTimeoutError
 
 from calico import common
-from calico.common import ValidationFailed, KNOWN_RULE_KEYS
+from calico.common import ValidationFailed
 from calico.datamodel_v1 import (VERSION_DIR, READY_KEY, CONFIG_DIR,
                                  RULES_KEY_RE, TAGS_KEY_RE, ENDPOINT_KEY_RE,
                                  dir_for_per_host_config,
-                                 get_profile_id_for_profile_dir, dir_for_host,
                                  PROFILE_DIR, HOST_DIR, EndpointId)
 from calico.felix.actor import Actor, actor_message
 
@@ -52,6 +52,23 @@ PREFIXES_TO_RESYNC_ON_CHANGE = [
     HOST_DIR,
 ]
 
+# Map etcd event actions to the effects we care about.
+ACTION_MAPPING = {
+    "set": "set",
+    "compareAndSwap": "set",
+    "create": "set",
+    "update": "set",
+
+    "delete": "delete",
+    "compareAndDelete": "delete",
+    "expire": "delete",
+}
+
+
+class Capture(object):
+    def __init__(self, name):
+        self.name = name
+
 
 class EtcdWatcher(Actor):
     def __init__(self, config):
@@ -59,6 +76,74 @@ class EtcdWatcher(Actor):
         self.config = config
         self.client = None
         self.my_config_dir = dir_for_per_host_config(self.config.HOSTNAME)
+
+        # Initialized at poll start time.
+        self.splitter = None
+        self.next_etcd_index = None
+
+        # Cache of known endpoints, used to resolve deletions of whole
+        # directory trees.
+        self.endpoint_ids_per_host = defaultdict(set)
+
+        self.handlers = {
+            "delete": self.force_resync,
+
+            "Ready": {
+                "set": self.on_ready,
+                "delete": self.force_resync,
+            },
+
+            "policy": {
+                "delete": self.force_resync,
+
+                "profile": {
+                    "delete": self.force_resync,
+
+                    "capture": ("profile_id",  {
+                        "delete": self.on_profile_delete,
+
+                        "tags": {
+                            "delete": self.on_tags_delete,
+                            "set": self.on_tags_set,
+                        },
+
+                        "rules": {
+                            "delete": self.on_rules_delete,
+                            "set": self.on_rules_set,
+                        }
+                    })
+                }
+            },
+
+            "host": {
+                "delete": self.force_resync,
+
+                "capture": ("hostname",  {
+                    "delete": self.on_host_delete,
+
+                    "workload": {
+                        "delete": self.on_host_delete,
+
+                        "capture": ("orchestrator",  {
+                            "delete": self.on_orch_delete,
+
+                            "capture": ("workload_id",  {
+                                "delete": self.on_workload_delete,
+
+                                "endpoint": {
+                                    "delete": self.on_workload_delete,
+
+                                    "capture": ("endpoint_id",  {
+                                        "delete": self.on_endpoint_delete,
+                                        "set": self.on_endpoint_set
+                                    })
+                                }
+                            })
+                        })
+                    }
+                })
+            }
+        }
 
     @actor_message()
     def load_config(self):
@@ -142,195 +227,264 @@ class EtcdWatcher(Actor):
 
         :returns: Does not return.
         """
+        self.splitter = update_splitter
         while True:
             _log.info("Reconnecting and loading snapshot from etcd...")
             self._reconnect(copy_cluster_id=False)
             self.wait_for_ready()
 
-            # Load initial dump from etcd.  First just get all the endpoints
-            # and profiles by id.  The response contains a generation ID
-            # allowing us to then start polling for updates without missing
-            # any.
-            initial_dump = self.client.read(VERSION_DIR, recursive=True)
-            _log.info("Loaded snapshot from etcd cluster %s, parsing it...",
-                      self.client.expected_cluster_id)
-            rules_by_id = {}
-            tags_by_id = {}
-            endpoints_by_id = {}
-            still_ready = False
-            for child in initial_dump.children:
-                profile_id, rules = parse_if_rules(child)
-                if profile_id:
-                    rules_by_id[profile_id] = rules
-                    continue
-                profile_id, tags = parse_if_tags(child)
-                if profile_id:
-                    tags_by_id[profile_id] = tags
-                    continue
-                endpoint_id, endpoint = parse_if_endpoint(self.config, child)
-                if endpoint_id and endpoint:
-                    endpoints_by_id[endpoint_id] = endpoint
-                    continue
+            try:
+                # Load initial dump from etcd.  First just get all the
+                # endpoints and profiles by id.  The response contains a
+                # generation ID allowing us to then start polling for updates
+                # without missing any.
+                self.load_initial_dump()
+                while True:
+                    # Wait for something to change.
+                    response = self._wait_for_etcd_event()
 
-                # Double-check the flag hasn't changed since we read it before.
-                if child.key == READY_KEY:
-                    if child.value == "true":
-                        still_ready = True
-                    else:
-                        _log.warning("Aborting resync because ready flag was"
-                                     "unset since we read it.")
-                        continue
+                    # Extract parts of the key following /calico/v1/
+                    key_parts = response.key.strip("/").split("/")[2:]
 
-            if not still_ready:
-                _log.warn("Aborting resync; ready flag no longer present.")
+                    # Actually deal with this event.
+                    self.handle_event(key_parts, response, self.handlers)
+            except ResyncRequired:
+                _log.info("Polling aborted, doing resync.")
+
+    def load_initial_dump(self):
+        """
+        Loads a snapshot from etcd and passes it to the update splitter.
+
+        :raises ResyncRequired: if the Ready flag is not set in the snapshot.
+        """
+        initial_dump = self.client.read(VERSION_DIR, recursive=True)
+        _log.info("Loaded snapshot from etcd cluster %s, parsing it...",
+                  self.client.expected_cluster_id)
+        rules_by_id = {}
+        tags_by_id = {}
+        endpoints_by_id = {}
+        self.endpoint_ids_per_host.clear()
+        still_ready = False
+        for child in initial_dump.children:
+            profile_id, rules = parse_if_rules(child)
+            if profile_id:
+                rules_by_id[profile_id] = rules
+                continue
+            profile_id, tags = parse_if_tags(child)
+            if profile_id:
+                tags_by_id[profile_id] = tags
+                continue
+            endpoint_id, endpoint = parse_if_endpoint(self.config, child)
+            if endpoint_id and endpoint:
+                endpoints_by_id[endpoint_id] = endpoint
+                self.endpoint_ids_per_host[endpoint_id.host].add(endpoint_id)
                 continue
 
-            # Actually apply the snapshot. This does not return anything, but
-            # just sends the relevant messages to the relevant threads to make
-            # all the processing occur.
-            _log.info("Snapshot parsed, passing to update splitter")
-            update_splitter.apply_snapshot(rules_by_id,
-                                           tags_by_id,
-                                           endpoints_by_id,
-                                           async=False)
+            # Double-check the flag hasn't changed since we read it before.
+            if child.key == READY_KEY:
+                if child.value == "true":
+                    still_ready = True
+                else:
+                    _log.warning("Aborting resync because ready flag was"
+                                 "unset since we read it.")
+                    raise ResyncRequired()
 
-            # These read only objects are no longer required, so tidy them up.
-            del rules_by_id
-            del tags_by_id
-            del endpoints_by_id
+        if not still_ready:
+            _log.warn("Aborting resync; ready flag no longer present.")
+            raise ResyncRequired()
 
-            # On first call, the etcd_index seems to be the high-water mark
-            # for the data returned whereas the modified index just tells us
-            # when the key was modified.
-            _log.info("Starting polling for updates from etcd.  Initial etcd "
-                      "index: %s.", initial_dump.etcd_index)
-            next_etcd_index = initial_dump.etcd_index + 1
-            del initial_dump
-            continue_polling = True
-            while continue_polling:
-                response = None
-                try:
-                    _log.debug("About to wait for etcd update %s",
-                               next_etcd_index)
-                    response = self.client.read(VERSION_DIR,
-                                                wait=True,
-                                                waitIndex=next_etcd_index,
-                                                recursive=True,
-                                                timeout=Timeout(connect=10,
-                                                                read=90),
-                                                check_cluster_uuid=True)
-                    _log.debug("etcd response: %r", response)
-                except (ReadTimeoutError, SocketTimeout) as e:
-                    # This is expected when we're doing a poll and nothing
-                    # happened. socket timeout doesn't seem to be caught by
-                    # urllib3 1.7.1.  Simply reconnect.
-                    _log.debug("Read from etcd timed out (%r), retrying.", e)
-                    # Force a reconnect to ensure urllib3 doesn't recycle the
-                    # connection.  (We were seeing this with urllib3 1.7.1.)
+        # Actually apply the snapshot. This does not return anything, but
+        # just sends the relevant messages to the relevant threads to make
+        # all the processing occur.
+        _log.info("Snapshot parsed, passing to update splitter")
+        self.splitter.apply_snapshot(rules_by_id,
+                                     tags_by_id,
+                                     endpoints_by_id,
+                                     async=False)
+        # The etcd_index is the high-water-mark for the snapshot, record that
+        # we want to poll starting at the next index.
+        self.next_etcd_index = initial_dump.etcd_index + 1
+
+    def _wait_for_etcd_event(self):
+        """
+        Polls etcd until something changes.
+
+        Retries on read timeouts and other non-fatal errors.
+
+        :returns: The etcd response object for the change.
+        :raises ResyncRequired: If we get out of sync with etcd or hit
+            a fatal error.
+        """
+        response = None
+        while not response:
+            try:
+                _log.debug("About to wait for etcd update %s",
+                           self.next_etcd_index)
+                response = self.client.read(VERSION_DIR,
+                                            wait=True,
+                                            waitIndex=self.next_etcd_index,
+                                            recursive=True,
+                                            timeout=Timeout(connect=10,
+                                                            read=90),
+                                            check_cluster_uuid=True)
+                _log.debug("etcd response: %r", response)
+            except (ReadTimeoutError, SocketTimeout) as e:
+                # This is expected when we're doing a poll and nothing
+                # happened. socket timeout doesn't seem to be caught by
+                # urllib3 1.7.1.  Simply reconnect.
+                _log.debug("Read from etcd timed out (%r), retrying.", e)
+                # Force a reconnect to ensure urllib3 doesn't recycle the
+                # connection.  (We were seeing this with urllib3 1.7.1.)
+                self._reconnect()
+            except (ConnectTimeoutError,
+                    urllib3.exceptions.HTTPError,
+                    httplib.HTTPException):
+                _log.warning("Low-level HTTP error, reconnecting to "
+                             "etcd.", exc_info=True)
+                self._reconnect()
+            except (EtcdClusterIdChanged, EtcdEventIndexCleared) as e:
+                _log.warning("Out of sync with etcd (%r).  Reconnecting "
+                             "for full sync.", e)
+                raise ResyncRequired()
+            except EtcdException as e:
+                # Sadly, python-etcd doesn't have a dedicated exception
+                # for the "no more machines in cluster" error. Parse the
+                # message:
+                msg = (e.message or "unknown").lower()
+                # Limit our retry rate in case etcd is down.
+                gevent.sleep(1)
+                if "no more machines" in msg:
+                    # This error comes from python-etcd when it can't
+                    # connect to any servers.  When we retry, it should
+                    # reconnect.
+                    # TODO: We should probably limit retries here and die
+                    # That'd recover from errors caused by resource
+                    # exhaustion/leaks.
+                    _log.error("Connection to etcd failed, will retry.")
+                else:
+                    # Assume any other errors are fatal to our poll and
+                    # do a full resync.
+                    _log.exception("Unknown etcd error %r; doing resync.",
+                                   e.message)
                     self._reconnect()
-                except (ConnectTimeoutError,
-                        urllib3.exceptions.HTTPError,
-                        httplib.HTTPException):
-                    _log.warning("Low-level HTTP error, reconnecting to "
-                                 "etcd.", exc_info=True)
-                    self._reconnect()
-                except (EtcdClusterIdChanged, EtcdEventIndexCleared) as e:
-                    _log.warning("Out of sync with etcd (%r).  Reconnecting "
-                                 "for full sync.", e)
-                    continue_polling = False
-                except EtcdException as e:
-                    # Sadly, python-etcd doesn't have a dedicated exception
-                    # for the "no more machines in cluster" error. Parse the
-                    # message:
-                    msg = (e.message or "unknown").lower()
-                    if "no more machines" in msg:
-                        # This error comes from python-etcd when it can't
-                        # connect to any servers.  When we retry, it should
-                        # reconnect.
-                        # TODO: We should probably limit retries here and die
-                        # That'd recover from errors caused by resource
-                        # exhaustion/leaks.
-                        _log.error("Connection to etcd failed, will retry.")
-                    else:
-                        # Assume any other errors are fatal to our poll and
-                        # do a full resync.
-                        _log.exception("Unknown etcd error %r; doing resync.",
-                                       e.message)
-                        continue_polling = False
-                    # TODO: should we do a backoff here?
-                    gevent.sleep(1)
-                    self._reconnect()
-                except:
-                    _log.exception("Unexpected exception during etcd poll")
-                    raise
+                    raise ResyncRequired()
+            except:
+                _log.exception("Unexpected exception during etcd poll")
+                raise
 
-                if not response:
-                    _log.debug("Failed to get a response from etcd.")
-                    continue
+        # Since we're polling on a subtree, we can't just increment
+        # the index, we have to look at the modifiedIndex to spot
+        # if we've skipped a lot of updates.
+        self.next_etcd_index = max(self.next_etcd_index,
+                                   response.modifiedIndex) + 1
+        return response
 
-                # Since we're polling on a subtree, we can't just increment
-                # the index, we have to look at the modifiedIndex to spot if
-                # we've skipped a lot of updates.
-                next_etcd_index = max(next_etcd_index,
-                                      response.modifiedIndex) + 1
+    def handle_event(self, key_parts, response, handlers,  captures=None):
+        if captures is None:
+            captures = {}
+        if not key_parts:
+            # We've reached the end of the key.
+            action = ACTION_MAPPING.get(response.action)
+            if action in handlers:
+                _log.debug("Found handler for event %s for %s, captures: %s",
+                           action, response.key, captures)
+                handlers[action](response, **captures)
+            else:
+                _log.debug("No handler for event %s on %s",
+                           action, response.key)
+        else:
+            next_part = key_parts[0]
+            key_parts = key_parts[1:]
+            if "capture" in handlers:
+                capture_name, sub_handler = handlers["capture"]
+                captures[capture_name] = next_part
+            elif next_part in handlers:
+                sub_handler = handlers[next_part]
+            else:
+                _log.debug("No matching sub-handler for %s", response.key)
+                return
+            self.handle_event(key_parts, response, sub_handler,
+                              captures=captures)
 
-                if response.action == "delete":
-                    # Handle expected directory deletions by faking events for
-                    # child nodes.
-                    profile_id = get_profile_id_for_profile_dir(response.key)
-                    if profile_id:
-                        _log.info("Delete for whole profile %s", profile_id)
-                        update_splitter.on_rules_update(profile_id, None,
-                                                        async=False)
-                        update_splitter.on_tags_update(profile_id, None,
-                                                       async=False)
-                        continue
-                    # TODO: Do we need to handle workload deletions?
+    def force_resync(self, response, **kwargs):
+        raise ResyncRequired()
 
-                profile_id, rules = parse_if_rules(response)
-                if profile_id:
-                    _log.info("Scheduling profile update %s", profile_id)
-                    update_splitter.on_rules_update(profile_id, rules,
-                                                    async=False)
-                    continue
-                profile_id, tags = parse_if_tags(response)
-                if profile_id:
-                    _log.info("Scheduling tags update %s", profile_id)
-                    update_splitter.on_tags_update(profile_id, tags,
-                                                   async=False)
-                    continue
-                endpoint_id, endpoint = parse_if_endpoint(self.config,
-                                                          response)
-                if endpoint_id:
-                    _log.info("Scheduling endpoint update %s", endpoint_id)
-                    update_splitter.on_endpoint_update(endpoint_id, endpoint,
-                                                       async=False)
-                    continue
+    def on_ready(self, response):
+        if response.value != "true":
+            raise ResyncRequired()
 
-                if response.key == READY_KEY:
-                    if response.value != "true":
-                        _log.warning("DB became unready, triggering a resync")
-                        continue_polling = False
-                    continue
+    def on_endpoint_set(self, response, hostname, orchestrator,
+                           workload_id, endpoint_id):
+        combined_id = EndpointId(hostname, orchestrator, workload_id,
+                                 endpoint_id)
+        _log.debug("Endpoint %s updated", combined_id)
+        self.endpoint_ids_per_host[combined_id.host].add(combined_id)
+        endpoint = parse_endpoint(self.config, endpoint_id, response.value)
+        self.splitter.on_endpoint_update(combined_id, endpoint)
 
-                _log.debug("Response action: %s, key: %s",
-                           response.action, response.key)
-                if (response.action not in ("set", "create") and
-                        any((response.key.startswith(pfx) for pfx in
-                             PREFIXES_TO_RESYNC_ON_CHANGE))):
-                    # Catch deletions of whole directories or other operations
-                    # that we're not expecting.
-                    _log.warning("Unexpected event: %s; triggering resync.",
-                                 response)
-                    continue_polling = False
-                if response.key.startswith(CONFIG_DIR):
-                    _log.warning("Global config changed but we don't "
-                                 "yet support dynamic config: %s",
-                                 response)
-                if response.key.startswith(self.my_config_dir):
-                    _log.warning("Config for this felix changed but we don't "
-                                 "yet support dynamic config: %s",
-                                 response)
+    def on_endpoint_delete(self, response, hostname, orchestrator,
+                           workload_id, endpoint_id):
+        combined_id = EndpointId(hostname, orchestrator, workload_id,
+                                 endpoint_id)
+        _log.debug("Endpoint %s deleted", combined_id)
+        self.endpoint_ids_per_host[combined_id.host].discard(combined_id)
+        if not self.endpoint_ids_per_host[combined_id.host]:
+            del self.endpoint_ids_per_host[combined_id.host]
+        self.splitter.on_endpoint_update(combined_id, None)
+
+    def on_rules_set(self, response, profile_id):
+        _log.debug("Rules for %s set", profile_id)
+        rules = parse_rules(profile_id, response.value)
+        self.splitter.on_rules_update(profile_id, rules)
+
+    def on_rules_delete(self, response, profile_id):
+        _log.debug("Rules for %s deleted", profile_id)
+        self.splitter.on_rules_update(profile_id, None)
+
+    def on_tags_set(self, response, profile_id):
+        _log.debug("Tags for %s set", profile_id)
+        rules = parse_tags(profile_id, response.value)
+        self.splitter.on_tags_update(profile_id, rules)
+
+    def on_tags_delete(self, response, profile_id):
+        _log.debug("Tags for %s deleted", profile_id)
+        self.splitter.on_tags_update(profile_id, None)
+
+    def on_profile_delete(self, response, profile_id):
+        # Fake deletes for the rules and tags.
+        _log.debug("Whole profile %s deleted", profile_id)
+        self.splitter.on_rules_update(profile_id, None)
+        self.splitter.on_tags_update(profile_id, None)
+
+    def on_host_delete(self, response, hostname):
+        ids_on_that_host = self.endpoint_ids_per_host.pop(hostname, set())
+        _log.info("Host %s deleted, removing %d endpoints",
+                  hostname, len(ids_on_that_host))
+        for endpoint_id in ids_on_that_host:
+            self.splitter.on_endpoint_update(endpoint_id, None, async=True)
+
+    def on_orch_delete(self, response, hostname, orchestrator):
+        _log.info("Orchestrator dir %s/%s deleted, removing contained hosts",
+                  hostname, orchestrator)
+        for endpoint_id in list(self.endpoint_ids_per_host[hostname]):
+            if endpoint_id.orchestrator == orchestrator:
+                self.splitter.on_endpoint_update(endpoint_id, None, async=True)
+                self.endpoint_ids_per_host[hostname].discard(endpoint_id)
+        if not self.endpoint_ids_per_host[hostname]:
+            del self.endpoint_ids_per_host[hostname]
+
+    def on_workload_delete(self, response, hostname, orchestrator,
+                           workload_id):
+        _log.info("Workload dir %s/%s/%s deleted, removing contained hosts",
+                  hostname, orchestrator, workload_id)
+        for endpoint_id in list(self.endpoint_ids_per_host[hostname]):
+            if (endpoint_id.orchestrator == orchestrator and
+                    endpoint_id.workload == workload_id):
+                self.splitter.on_endpoint_update(endpoint_id, None, async=True)
+                self.endpoint_ids_per_host[hostname].discard(endpoint_id)
+        if not self.endpoint_ids_per_host[hostname]:
+            del self.endpoint_ids_per_host[hostname]
+
 
 def _build_config_dict(cfg_node):
     """
@@ -363,40 +517,49 @@ def parse_if_endpoint(config, etcd_node):
             _log.debug("Found deleted endpoint %s", endpoint_id)
             endpoint = None
         else:
-            endpoint = json_decoder.decode(etcd_node.value)
-            try:
-                common.validate_endpoint(config, endpoint)
-            except ValidationFailed as e:
-                _log.warning("Validation failed for endpoint %s, treating as "
-                             "missing: %s", endpoint_id, e.message)
-                endpoint = None
-            else:
-                _log.debug("Validated endpoint : %s", endpoint)
+            endpoint = parse_endpoint(config, endpoint_id, etcd_node.value)
         return EndpointId(host, orch, workload_id, endpoint_id), endpoint
     return None, None
 
 
+def parse_endpoint(config, endpoint_id, raw_json):
+    endpoint = json_decoder.decode(raw_json)
+    try:
+        common.validate_endpoint(config, endpoint)
+    except ValidationFailed as e:
+        _log.warning("Validation failed for endpoint %s, treating as "
+                     "missing: %s", endpoint_id, e.message)
+        endpoint = None
+    else:
+        _log.debug("Validated endpoint : %s", endpoint)
+    return endpoint
+
+
 def parse_if_rules(etcd_node):
     m = RULES_KEY_RE.match(etcd_node.key)
+    rules = None
     if m:
         # Got some rules.
         profile_id = m.group("profile_id")
         if etcd_node.action == "delete":
             rules = None
         else:
-            rules = json_decoder.decode(etcd_node.value)
-            rules["id"] = profile_id
-            try:
-                common.validate_rules(rules)
-            except ValidationFailed:
-                _log.exception("Validation failed for profile %s rules: %s",
-                               profile_id, rules)
-                return profile_id, None
-
-        _log.debug("Found rules for profile %s : %s", profile_id, rules)
-
+            rules = parse_rules(profile_id, etcd_node.value)
         return profile_id, rules
     return None, None
+
+
+def parse_rules(profile_id, raw_json):
+    rules = json_decoder.decode(raw_json)
+    rules["id"] = profile_id
+    try:
+        common.validate_rules(rules)
+    except ValidationFailed:
+        _log.exception("Validation failed for profile %s rules: %s",
+                       profile_id, rules)
+        return None
+    else:
+        return rules
 
 
 def parse_if_tags(etcd_node):
@@ -407,15 +570,22 @@ def parse_if_tags(etcd_node):
         if etcd_node.action == "delete":
             tags = None
         else:
-            tags = json_decoder.decode(etcd_node.value)
-            try:
-                common.validate_tags(tags)
-            except ValidationFailed:
-                _log.exception("Validation failed for profile %s tags : %s",
-                               profile_id, tags)
-                return profile_id, None
-
-        _log.debug("Found tags for profile %s : %s", profile_id, tags)
-
+            tags = parse_tags(profile_id, etcd_node.value)
         return profile_id, tags
     return None, None
+
+
+def parse_tags(profile_id, raw_json):
+    tags = json_decoder.decode(raw_json)
+    try:
+        common.validate_tags(tags)
+    except ValidationFailed:
+        _log.exception("Validation failed for profile %s tags : %s",
+                       profile_id, tags)
+        return None
+    else:
+        return tags
+
+
+class ResyncRequired(Exception):
+    pass

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -1,0 +1,326 @@
+# Copyright (c) Metaswitch Networks 2015. All rights reserved.
+import json
+
+import logging
+import types
+from etcd import EtcdResult
+from mock import Mock, patch, call
+from calico.datamodel_v1 import EndpointId
+from calico.felix.fetcd import PathDispatcher, EtcdWatcher, ResyncRequired
+from calico.felix.splitter import UpdateSplitter
+from calico.felix.test.base import BaseTestCase
+
+_log = logging.getLogger(__name__)
+
+
+SAME_AS_KEY = object()
+
+VALID_ENDPOINT = {
+    "state": "active",
+    "name": "tap1234",
+    "mac": "aa:bb:cc:dd:ee:ff",
+    "profile_id": "prof1",
+    "ipv4_nets": [
+        "10.0.0.1/32",
+    ],
+    "ipv6_nets": [
+        "dead::beef/128"
+    ]
+}
+ENDPOINT_STR = json.dumps(VALID_ENDPOINT)
+
+RULES = {
+    "inbound_rules": [],
+    "outbound_rules": [],
+}
+RULES_STR = json.dumps(RULES)
+
+TAGS = ["a", "b"]
+TAGS_STR = json.dumps(TAGS)
+
+
+class TestExcdWatcher(BaseTestCase):
+
+    def setUp(self):
+        super(TestExcdWatcher, self).setUp()
+        m_config = Mock()
+        m_config.IFACE_PREFIX = "tap"
+        self.watcher = EtcdWatcher(m_config)
+        self.m_splitter = Mock(spec=UpdateSplitter)
+        self.watcher.splitter = self.m_splitter
+
+    def test_ready_flag_set(self):
+        self.dispatch("/calico/v1/Ready", "set", value="true")
+        with self.assertRaises(ResyncRequired):
+            self.dispatch("/calico/v1/Ready", "set", value="false")
+        with self.assertRaises(ResyncRequired):
+            self.dispatch("/calico/v1/Ready", "set", value="foo")
+
+    def test_endpoint_set(self):
+        self.dispatch("/calico/v1/host/h1/workload/o1/w1/endpoint/e1",
+                      "set", value=ENDPOINT_STR)
+        self.m_splitter.on_endpoint_update.assert_called_once_with(
+            EndpointId("h1", "o1", "w1", "e1"),
+            VALID_ENDPOINT,
+            async=True,
+        )
+
+    def test_parent_dir_delete(self):
+        """
+        Test that deletions of parent directories of endpoints are
+        correctly handled.
+        """
+        # This additional  endpoint should be ignored by the deletes below.
+        self.dispatch("/calico/v1/host/h2/workload/o1/w2/endpoint/e2",
+                      "set", value=ENDPOINT_STR)
+        for path in ["/calico/v1/host/h1",
+                     "/calico/v1/host/h1/workload",
+                     "/calico/v1/host/h1/workload/o1",
+                     "/calico/v1/host/h1/workload/o1/w1",
+                     "/calico/v1/host/h1/workload/o1/w1/endpoint"]:
+            # Create endpoints in the cache.
+            self.dispatch("/calico/v1/host/h1/workload/o1/w1/endpoint/e1",
+                          "set", value=ENDPOINT_STR)
+            self.dispatch("/calico/v1/host/h1/workload/o1/w1/endpoint/e2",
+                          "set", value=ENDPOINT_STR)
+            # This endpoint should not get cleaned up if only workload w1 is
+            # deleted...
+            self.dispatch("/calico/v1/host/h1/workload/o1/w3/endpoint/e3",
+                          "set", value=ENDPOINT_STR)
+
+            self.assertEqual(self.watcher.endpoint_ids_per_host, {
+                "h1": set([EndpointId("h1", "o1", "w1", "e1"),
+                           EndpointId("h1", "o1", "w1", "e2"),
+                           EndpointId("h1", "o1", "w3", "e3")]),
+                "h2": set([EndpointId("h2", "o1", "w2", "e2")]),
+            })
+            self.m_splitter.on_endpoint_update.reset_mock()
+            # Delete one of its parent dirs, should delete the endpoint.
+            self.dispatch(path, "delete")
+            exp_calls = [
+                call(EndpointId("h1", "o1", "w1", "e1"), None, async=True),
+                call(EndpointId("h1", "o1", "w1", "e2"), None, async=True),
+            ]
+            if path < "/calico/v1/host/h1/workload/o1/w1":
+                # Should also delete workload w3.
+                exp_calls.append(call(EndpointId("h1", "o1", "w3", "e3"),
+                                      None, async=True))
+            self.m_splitter.on_endpoint_update.assert_has_calls(exp_calls,
+                                                                any_order=True)
+            # Cache should be cleaned up.
+            exp_cache = {"h2": set([EndpointId("h2", "o1", "w2", "e2")])}
+            if path >= "/calico/v1/host/h1/workload/o1/w1":
+                # Should not have deleted workload w3.  Add it in.
+                exp_cache["h1"] = set([EndpointId("h1", "o1", "w3", "e3")])
+            self.assertEqual(self.watcher.endpoint_ids_per_host, exp_cache)
+
+            # Then simulate another delete, should have no effect.
+            self.m_splitter.on_endpoint_update.reset_mock()
+            self.dispatch(path, "delete")
+            self.assertFalse(self.m_splitter.on_endpoint_update.called)
+
+    def test_rules_set(self):
+        self.dispatch("/calico/v1/policy/profile/prof1/rules", "set",
+                      value=RULES_STR)
+        self.m_splitter.on_rules_update("prof1", RULES, async=True)
+
+    def test_tags_set(self):
+        self.dispatch("/calico/v1/policy/profile/prof1/tags", "set",
+                      value=TAGS_STR)
+        self.m_splitter.on_tags_update("prof1", TAGS, async=True)
+
+    def test_dispatch_delete_resync(self):
+        """
+        Test dispatcher is correctly configured to trigger resync for
+        expected paths.
+        """
+        for key in ["/calico/v1",
+                    "/calico/v1/host",
+                    "/calico/v1/policy",
+                    "/calico/v1/policy/profile",
+                    "/calico/v1/config",
+                    "/calico/v1/Ready",]:
+            with self.assertRaises(ResyncRequired):
+                self.dispatch(key, "delete")
+
+    def test_per_profile_del(self):
+        """
+        Test profile deletion triggers dleetion for tags and rules.
+        """
+        self.dispatch("/calico/v1/policy/profile/profA", action="delete")
+        self.m_splitter.on_tags_update.assert_called_once_with("profA", None,
+                                                               async=True)
+        self.m_splitter.on_rules_update.assert_called_once_with("profA", None,
+                                                               async=True)
+
+    def test_tags_del(self):
+        """
+        Test tag-only deletion.
+        """
+        self.dispatch("/calico/v1/policy/profile/profA/tags", action="delete")
+        self.m_splitter.on_tags_update.assert_called_once_with("profA", None,
+                                                               async=True)
+        self.assertFalse(self.m_splitter.on_rules_update.called)
+
+    def test_rules_del(self):
+        """
+        Test rules-only deletion.
+        """
+        self.dispatch("/calico/v1/policy/profile/profA/rules", action="delete")
+        self.m_splitter.on_rules_update.assert_called_once_with("profA", None,
+                                                               async=True)
+        self.assertFalse(self.m_splitter.on_tags_update.called)
+
+    def test_endpoint_del(self):
+        """
+        Test endpoint-only deletion.
+        """
+        self.dispatch("/calico/v1/host/h1/workload/o1/w1/endpoint/e1",
+                      action="delete")
+        self.m_splitter.on_endpoint_update.assert_called_once_with(
+            EndpointId("h1", "o1", "w1", "e1"),
+            None,
+            async=True,
+        )
+
+    def dispatch(self, key, action, value=None):
+        """
+        Send an EtcdResult to the watcher's dispatcher.
+        """
+        m_response = Mock(spec=EtcdResult)
+        m_response.key = key
+        m_response.action = action
+        m_response.value = value
+        self.watcher.dispatcher.handle_event(m_response)
+
+
+class _TestPathDispatcherBase(BaseTestCase):
+    """
+    Abstract base class for Dispatcher tests.
+    """
+    # Etcd action that this class tests.
+    action = None
+    # Expected handler type, "set" or "delete".
+    expected_handlers = None
+
+    def setUp(self):
+        super(_TestPathDispatcherBase, self).setUp()
+        self.dispatcher = PathDispatcher()
+        self.handlers = {
+            "delete": {},
+            "set": {},
+        }
+        self.register("/")
+        self.register("/a")
+        self.register("/a/<b>")
+        self.register("/a/<b>/c")
+        self.register("/a/<b>/d")
+        self.register("/a/<b>/d/<e>")
+
+    def register(self, key):
+        m_on_set = Mock()
+        m_on_del = Mock()
+        self.dispatcher.register(key, on_set=m_on_set, on_del=m_on_del)
+        self.handlers["set"][key.strip("/")] = m_on_set
+        self.handlers["delete"][key.strip("/")] = m_on_del
+
+    def assert_handled(self, key, exp_handler=SAME_AS_KEY, **exp_captures):
+        if exp_handler is SAME_AS_KEY:
+            exp_handler = key
+        if exp_handler is not None:
+            exp_handler = exp_handler.strip("/")
+        m_response = Mock(spec=EtcdResult)
+        m_response.key = key
+        m_response.action = self.action
+        self.dispatcher.handle_event(m_response)
+        exp_handlers = self.handlers[self.expected_handlers]
+        for handler_key, handler in exp_handlers.iteritems():
+            if handler_key == exp_handler:
+                continue
+            self.assertFalse(handler.called,
+                             "Unexpected set handler %s was called for "
+                             "key %s" % (handler_key, key))
+        unexp_handlers = self.handlers[self.unexpected_handlers]
+        for handler_key, handler in unexp_handlers.iteritems():
+            self.assertFalse(handler.called,
+                             "Unexpected del handler %s was called for "
+                             "key %s" % (handler_key, key))
+        if exp_handler is not None:
+            exp_handlers[exp_handler].assert_called_once_with(
+                m_response, **exp_captures)
+
+    @property
+    def unexpected_handlers(self):
+        if self.expected_handlers == "set":
+            return "delete"
+        else:
+            return "set"
+
+    def test_dispatch_root(self):
+        self.assert_handled("/")
+
+    def test_dispatch_no_captures(self):
+        self.assert_handled("/a")
+
+    def test_dispatch_capture(self):
+        self.assert_handled("/a/bval", exp_handler="/a/<b>", b="bval")
+
+    def test_dispatch_after_capture(self):
+        self.assert_handled("/a/bval/c", exp_handler="/a/<b>/c", b="bval")
+
+    def test_dispatch_after_capture_2(self):
+        self.assert_handled("/a/bval/d", exp_handler="/a/<b>/d", b="bval")
+
+    def test_multi_capture(self):
+        self.assert_handled("/a/bval/d/eval",
+                            exp_handler="/a/<b>/d/<e>",
+                            b="bval", e="eval")
+
+    def test_non_match(self):
+        self.assert_handled("/a/bval/c/eval", exp_handler=None)
+        self.assert_handled("/foo", exp_handler=None)
+
+    def test_cover_no_match(self):
+        m_result = Mock(spec=EtcdResult)
+        m_result.key = "/a"
+        m_result.action = "unknown"
+        self.dispatcher.handle_event(m_result)
+        for handlers in self.handlers.itervalues():
+            for key, handler in handlers.iteritems():
+                self.assertFalse(handler.called,
+                                 msg="Unexpected handler called: %s" % key)
+
+
+class TestDispatcherSet(_TestPathDispatcherBase):
+    action = "set"
+    expected_handlers = "set"
+
+
+class TestDispatcherCaS(_TestPathDispatcherBase):
+    action = "compareAndSwap"
+    expected_handlers = "set"
+
+
+class TestDispatcherCreate(_TestPathDispatcherBase):
+    action = "create"
+    expected_handlers = "set"
+
+
+class TestDispatcherUpdate(_TestPathDispatcherBase):
+    action = "update"
+    expected_handlers = "set"
+
+
+class TestDispatcherDel(_TestPathDispatcherBase):
+    action = "delete"
+    expected_handlers = "delete"
+
+
+class TestDispatcherCaD(_TestPathDispatcherBase):
+    action = "compareAndDelete"
+    expected_handlers = "delete"
+
+
+class TestDispatcherExpire(_TestPathDispatcherBase):
+    action = "expire"
+    expected_handlers = "delete"

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -32,7 +32,8 @@ from oslo.config import cfg
 from calico.datamodel_v1 import (READY_KEY, CONFIG_DIR, TAGS_KEY_RE, HOST_DIR,
                                  key_for_endpoint, PROFILE_DIR,
                                  key_for_profile, key_for_profile_rules,
-                                 key_for_profile_tags, key_for_config)
+                                 key_for_profile_tags, key_for_config,
+                                 VERSION_DIR)
 from calico.openstack.transport import CalicoTransport
 
 # Register Calico-specific options.
@@ -198,11 +199,7 @@ class CalicoTransportEtcd(CalicoTransport):
                     # cases the etcd key is no longer valid and should be
                     # deleted.  In the migration case, data will be written
                     # below to an etcd key that incorporates the new hostname.
-                    try:
-                        self.client.delete(child.key)
-                    except etcd.EtcdKeyNotFound:
-                        LOG.debug("Key %s, which we were deleting, "
-                                  "disappeared", child.key)
+                    self._delete_key_and_empty_parents(child.key)
 
         # Now write etcd data for any endpoints remaining in the ports dict;
         # these are new endpoints - i.e. never previously represented in etcd
@@ -224,6 +221,30 @@ class CalicoTransportEtcd(CalicoTransport):
             self.needed_profiles -= self.profiles_to_clean_up
             self.profiles_to_clean_up.clear()
 
+    def _delete_key_and_empty_parents(self, key, stop_before=VERSION_DIR):
+        """
+        Tries to delete the given etcd key and then each of its
+        parent directories iff they are empty.
+        """
+        delete_failed = False
+        directory = False
+        assert key.startswith(stop_before), ("Key %s wasn't contained in %s" %
+                                             (key, stop_before))
+        while (len(key.strip("/")) > len(stop_before.strip("/")) and
+               not delete_failed):
+            try:
+                LOG.debug("Trying to delete %s %s",
+                          "directory" if directory else "key", key)
+                self.client.delete(key, dir=directory)
+            except etcd.EtcdKeyNotFound:
+                LOG.debug("Key %s, which we were deleting, disappeared", key)
+            except etcd.EtcdException as e:
+                # Expected when we try to delete a non-empty parent.
+                LOG.debug("Failed to delete %s (%r), giving up.", key, e)
+                delete_failed = True
+            else:
+                key = key.rpartition("/")[0]
+                directory = True
 
     def port_etcd_key(self, port):
         return key_for_endpoint(port['binding:host_id'],
@@ -390,11 +411,7 @@ class CalicoTransportEtcd(CalicoTransport):
     def endpoint_deleted(self, port):
         # Delete the etcd key for this endpoint.
         key = self.port_etcd_key(port)
-        try:
-            self.client.delete(key)
-        except etcd.EtcdKeyNotFound:
-            # Already gone, treat as success.
-            LOG.debug("Key %s, which we were deleting, disappeared", key)
+        self._delete_key_and_empty_parents(key, stop_before=HOST_DIR)
 
     def security_group_updated(self, sg):
         # Update the data that we're keeping for this security group.

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -588,6 +588,19 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
             'icmp_code': 100,
         })
 
+    def test_openstack_dirs_re(self):
+        self.assertFalse(t_etcd.OPENSTACK_DIRS_RE.match("/calico"))
+        self.assertFalse(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1"))
+        self.assertFalse(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/"))
+        self.assertFalse(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host"))
+        self.assertFalse(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host/"))
+
+        self.assertTrue(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host/abcd"))
+        self.assertTrue(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host/abcd/workload"))
+        self.assertTrue(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host/abcd/workload/openstack"))
+        self.assertTrue(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host/abcd/workload/openstack/instance-1"))
+        self.assertTrue(t_etcd.OPENSTACK_DIRS_RE.match("/calico/v1/host/abcd/workload/openstack/instance-1/endpoint"))
+
     def assertNeutronToEtcd(self, neutron_rule, exp_etcd_rule):
         etcd_rule = t_etcd._neutron_rule_to_etcd_rule(neutron_rule)
         self.assertEqual(etcd_rule, exp_etcd_rule)


### PR DESCRIPTION
* In the plugin, attempt to delete parent directories using etcd parameter dir=true.  That does a non-recursive delete, only if the directory is empty.
* In felix, cache the endpoint IDs in the etcd layer so we can generate delete events for the children of a deleted directory.  I did it this way because it avoided polluting the rest of the code with knowledge of the etcd directory structure.  (It doesn't mean much to the endpoint/tag manager that the orchestrator dir was deleted.)
* The old way of parsing was getting untenable so I devised a tree structure to hang the handlers from.
* Bit annoying that I've still got the parse_if... functions hanging around.  I'd like to clean those up but this fix is too important to block behind that.