### PR TITLE
Add support for list of profiles on endpoints.

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -261,12 +261,25 @@ def validate_endpoint(config, endpoint):
     elif endpoint["state"] not in ("active", "inactive"):
         issues.append("Expected 'state' to be one of active/inactive.")
 
-    for field in ["name", "mac", "profile_id"]:
+    for field in ["name", "mac"]:
         if field not in endpoint:
             issues.append("Missing '%s' field." % field)
         elif not isinstance(endpoint[field], StringTypes):
             issues.append("Expected '%s' to be a string; got %r." %
                           (field, endpoint[field]))
+
+    if "profile_id" in endpoint:
+        if "profile_ids" not in endpoint:
+            endpoint["profile_ids"] = [endpoint["profile_id"]]
+        del endpoint["profile_id"]
+
+    if "profile_ids" not in endpoint:
+        issues.append("Missing 'profile_id(s)' field.")
+    else:
+        for value in endpoint["profile_ids"]:
+            if not isinstance(value, StringTypes):
+                issues.append("Expected profile IDs to be strings.")
+                break
 
     if "name" in endpoint:
         if not endpoint["name"].startswith(config.IFACE_PREFIX):

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -52,7 +52,8 @@ RULES_KEY_RE = re.compile(
 # "profile_id".
 TAGS_KEY_RE = re.compile(
     r'^' + PROFILE_DIR + r'/(?P<profile_id>[^/]+)/tags')
-#
+# Regex to match profile refcounts, capturing the profile ID in capture group
+# "profile_id".
 PROFILE_REFCOUNT_RE = re.compile(
     r'^' + PROFILE_DIR + r'/(?P<profile_id>[^/]+)/refcount')
 # Regex to match endpoints, captures "hostname" and "endpoint_id".

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -52,6 +52,9 @@ RULES_KEY_RE = re.compile(
 # "profile_id".
 TAGS_KEY_RE = re.compile(
     r'^' + PROFILE_DIR + r'/(?P<profile_id>[^/]+)/tags')
+#
+PROFILE_REFCOUNT_RE = re.compile(
+    r'^' + PROFILE_DIR + r'/(?P<profile_id>[^/]+)/refcount')
 # Regex to match endpoints, captures "hostname" and "endpoint_id".
 ENDPOINT_KEY_RE = re.compile(
     r'^' + HOST_DIR +
@@ -85,6 +88,10 @@ def key_for_profile_rules(profile_id):
 
 def key_for_profile_tags(profile_id):
     return PROFILE_DIR + "/%s/tags" % profile_id
+
+
+def key_for_profile_refcount(profile_id):
+    return PROFILE_DIR + "/%s/refcount" % profile_id
 
 
 def key_for_config(config_name):

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -137,11 +137,11 @@ def rules_to_chain_rewrite_lines(chain_name, rules, ip_version, tag_to_ipset,
                                                         tag_to_ipset,
                                                         on_allow=on_allow,
                                                         on_deny=on_deny))
-    tag_part = " (%s)" % comment_tag if comment_tag else ""
-    fragments.append(commented_drop_fragment(
-        chain_name,
-        "Default DROP rule%s:" % tag_part)
-    )
+    # If we get to the end of the chain without a match, we mark the packet
+    # to let the caller know that we haven't accepted the packet.
+    fragments.append('--append %s --match comment '
+                     '--comment "Mark as not matched" '
+                     '--jump MARK --set-mark 1' % chain_name)
     return fragments
 
 

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -54,8 +54,10 @@ class IpsetManager(ReferenceManager):
         # endpoints, we need to track which endpoints reference an IP.  When
         # we find the set of endpoints with an IP is empty, we remove the
         # ip from the tag.
-        # ip_owners_by_tag[tag][ip] = set([endpoint_id, endpoint_id2, ...])
-        self.ip_owners_by_tag = defaultdict(lambda: defaultdict(set))
+        # ip_owners_by_tag[tag][ip][profile_id] = set([endpoint_id,
+        #                                              endpoint_id2, ...])
+        self.ip_owners_by_tag = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(set)))
 
         self.endpoint_ids_by_profile_id = defaultdict(set)
 
@@ -195,10 +197,10 @@ class IpsetManager(ReferenceManager):
             ip_addrs = self._extract_ips(endpoint)
             for tag_id in removed_tags:
                 for ip in ip_addrs:
-                    self._remove_mapping(tag_id, endpoint_id, ip)
+                    self._remove_mapping(tag_id, profile_id, endpoint_id, ip)
             for tag_id in added_tags:
                 for ip in ip_addrs:
-                    self._add_mapping(tag_id, endpoint_id, ip)
+                    self._add_mapping(tag_id, profile_id, endpoint_id, ip)
 
         if tags is None:
             _log.info("Tags for profile %s deleted", profile_id)
@@ -224,7 +226,7 @@ class IpsetManager(ReferenceManager):
         """
 
         # Endpoint updates are the most complex to handle because they may
-        # change the profile ID (and hence the set of tags) as well as the
+        # change the profile IDs (and hence the set of tags) as well as the
         # ip addresses attached to the interface.  In addition, the endpoint
         # may or may not have existed before.
         #
@@ -234,27 +236,29 @@ class IpsetManager(ReferenceManager):
         # when we calculate removed_tags, we'll get the empty set and the
         # removal loop will be skipped.
         old_endpoint = self.endpoints_by_ep_id.get(endpoint_id, {})
-        old_prof_id = old_endpoint.get("profile_id")
-        if old_prof_id:
-            old_tags = set(self.tags_by_prof_id.get(old_prof_id, []))
-        else:
-            old_tags = set()
+        old_prof_ids = set(old_endpoint.get("profile_ids", []))
+        old_tags = set()
+        for profile_id in old_prof_ids:
+            for tag in self.tags_by_prof_id.get(profile_id, []):
+                old_tags.add((profile_id, tag))
 
         if endpoint is None:
             _log.debug("Deletion, setting new_tags to empty.")
-            new_prof_id = None
-            new_tags = set()
+            new_prof_ids = set()
         else:
             _log.debug("Add/update, setting new_tags to indexed value.")
-            new_prof_id = endpoint.get("profile_id")
-            new_tags = set(self.tags_by_prof_id.get(new_prof_id, []))
+            new_prof_ids = set(endpoint.get("profile_ids", []))
+        new_tags = set()
+        for profile_id in new_prof_ids:
+            for tag in self.tags_by_prof_id.get(profile_id, []):
+                new_tags.add((profile_id, tag))
 
-        if new_prof_id != old_prof_id:
+        if new_prof_ids != old_prof_ids:
             # Profile ID changed, or an add/delete.  the _xxx_profile_index
             # methods ignore profile_id == None so we'll do the right thing.
             _log.debug("Profile ID changed from %s to %s")
-            self._remove_profile_index(old_prof_id, endpoint_id)
-            self._add_profile_index(new_prof_id, endpoint_id)
+            self._remove_profile_index(old_prof_ids, endpoint_id)
+            self._add_profile_index(new_prof_ids, endpoint_id)
 
         # Since we've defaulted new/old_tags to set() if needed, we can
         # use set operations to calculate the tag changes.
@@ -266,73 +270,67 @@ class IpsetManager(ReferenceManager):
         old_ips = self._extract_ips(old_endpoint)
         new_ips = self._extract_ips(endpoint)
 
-        # Remove *all* *old* IPs from removed tags.  For a deletion, only this
-        # loop will fire, removed_tags will be all tags and old_ips will be
-        # all the old IPs.
-        for tag in removed_tags:
-            for ip in old_ips:
-                self._remove_mapping(tag, endpoint_id, ip)
+        # Add *new* IPs to new tags.  On a deletion, added_tags will be empty.
+        # Do this first to avoid marking ipsets as dirty if an endpoint moves
+        # from one profile to another but keeps the same tag.
+        for profile_id, tag in added_tags:
+            for ip in new_ips:
+                self._add_mapping(tag, profile_id,  endpoint_id, ip)
         # Change IPs in unchanged tags.
         added_ips = new_ips - old_ips
         removed_ips = old_ips - new_ips
-        for tag in unchanged_tags:
+        for profile_id, tag in unchanged_tags:
             for ip in removed_ips:
-                self._remove_mapping(tag, endpoint_id, ip)
+                self._remove_mapping(tag, profile_id,  endpoint_id, ip)
             for ip in added_ips:
-                self._add_mapping(tag, endpoint_id, ip)
-        # Add *new* IPs to new tags.
-        for tag in added_tags:
-            for ip in new_ips:
-                self._add_mapping(tag, endpoint_id, ip)
+                self._add_mapping(tag, profile_id,  endpoint_id, ip)
+        # Remove *all* *old* IPs from removed tags.  For a deletion, only this
+        # loop will fire.
+        for profile_id, tag in removed_tags:
+            for ip in old_ips:
+                self._remove_mapping(tag, profile_id, endpoint_id, ip)
 
         _log.info("Endpoint update complete")
 
-    def _add_mapping(self, tag_id, endpoint_id, ip_address):
+    def _add_mapping(self, tag_id, profile_id, endpoint_id, ip_address):
         """
-        Adds the given tag->endpoint->IP mapping to the index and updates
-        the ActiveIpset if present.
-
-        :return: True if the IP wasn't already in that tag.
+        Adds the given tag->IP->profile->endpoint mapping to the index.
+        Marks the tag as dirty if the update resulted in the IP being
+        newly added.
         """
-        ep_ids = self.ip_owners_by_tag[tag_id][ip_address]
-        ip_added = not bool(ep_ids)
+        ip_added = not bool(self.ip_owners_by_tag[tag_id][ip_address])
+        ep_ids = self.ip_owners_by_tag[tag_id][ip_address][profile_id]
         ep_ids.add(endpoint_id)
         if ip_added:
             self._dirty_tags.add(tag_id)
-        return ip_added
 
-    def _remove_mapping(self, tag_id, endpoint_id, ip_address):
+    def _remove_mapping(self, tag_id, profile_id, endpoint_id, ip_address):
         """
-        Removes the tag->endpoint->IP mapping from indices and updates
-        any ActiveIpset if the IP is no longer present in the tag.
-
-        :return: True if the update resulted in removing that IP from the tag.
+        Removes the tag->IP->profile->endpoint mapping from index.
+        Marks the tag as dirty if the update resulted in the IP being
+        removed.
         """
-        ep_ids = self.ip_owners_by_tag[tag_id][ip_address]
+        ep_ids = self.ip_owners_by_tag[tag_id][ip_address][profile_id]
         ep_ids.discard(endpoint_id)
-        ip_removed = False
         if not ep_ids:
-            del self.ip_owners_by_tag[tag_id][ip_address]
-            self._dirty_tags.add(tag_id)
-            ip_removed = True
-        return ip_removed
+            del self.ip_owners_by_tag[tag_id][ip_address][profile_id]
+            if not self.ip_owners_by_tag[tag_id][ip_address]:
+                del self.ip_owners_by_tag[tag_id][ip_address]
+                self._dirty_tags.add(tag_id)
 
-    def _add_profile_index(self, prof_id, endpoint_id):
+    def _add_profile_index(self, prof_ids, endpoint_id):
         """
-        Notes in the index that an endpoint uses a profile.
-
-        Does nothing if profile_id == None.
+        Notes in the index that an endpoint uses the given profiles.
         """
-        if prof_id is not None:
+        for prof_id in prof_ids:
             self.endpoint_ids_by_profile_id[prof_id].add(endpoint_id)
 
-    def _remove_profile_index(self, prof_id, endpoint_id):
+    def _remove_profile_index(self, prof_ids, endpoint_id):
         """
-        Notes in the index that an endpoint no longer uses a profile.
-
-        Does nothing if profile_id == None.
+        Notes in the index that an endpoint no longer uses any of the
+        given profiles.
         """
-        if prof_id is not None:
+        for prof_id in prof_ids:
             endpoints = self.endpoint_ids_by_profile_id[prof_id]
             endpoints.discard(endpoint_id)
             if not endpoints:

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -235,7 +235,7 @@ class IpsetManager(ReferenceManager):
         # previous endpoint then we default old_tags to the empty set.  Then,
         # when we calculate removed_tags, we'll get the empty set and the
         # removal loop will be skipped.
-        old_endpoint = self.endpoints_by_ep_id.get(endpoint_id, {})
+        old_endpoint = self.endpoints_by_ep_id.pop(endpoint_id, {})
         old_prof_ids = set(old_endpoint.get("profile_ids", []))
         old_tags = set()
         for profile_id in old_prof_ids:
@@ -248,6 +248,7 @@ class IpsetManager(ReferenceManager):
         else:
             _log.debug("Add/update, setting new_tags to indexed value.")
             new_prof_ids = set(endpoint.get("profile_ids", []))
+            self.endpoints_by_ep_id[endpoint_id] = endpoint
         new_tags = set()
         for profile_id in new_prof_ids:
             for tag in self.tags_by_prof_id.get(profile_id, []):
@@ -256,7 +257,8 @@ class IpsetManager(ReferenceManager):
         if new_prof_ids != old_prof_ids:
             # Profile ID changed, or an add/delete.  the _xxx_profile_index
             # methods ignore profile_id == None so we'll do the right thing.
-            _log.debug("Profile ID changed from %s to %s")
+            _log.debug("Profile ID changed from %s to %s",
+                       old_prof_ids, new_prof_ids)
             self._remove_profile_index(old_prof_ids, endpoint_id)
             self._add_profile_index(new_prof_ids, endpoint_id)
 

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -319,6 +319,8 @@ class IpsetManager(ReferenceManager):
             if not self.ip_owners_by_tag[tag_id][ip_address]:
                 del self.ip_owners_by_tag[tag_id][ip_address]
                 self._dirty_tags.add(tag_id)
+            if not self.ip_owners_by_tag[tag_id]:
+                del self.ip_owners_by_tag[tag_id]
 
     def _add_profile_index(self, prof_ids, endpoint_id):
         """

--- a/calico/felix/refcount.py
+++ b/calico/felix/refcount.py
@@ -239,6 +239,15 @@ class RefHelper(object):
         Mapping from object ID to object that we've acquired.
         """
 
+    def replace_all(self, new_obj_ids):
+        """
+        Change the set of references we require to the given set.
+        """
+        for obj_id in new_obj_ids:
+            self.acquire_ref(obj_id)
+        for obj_id in [r for r in self.required_refs if r not in new_obj_ids]:
+            self.discard_ref(obj_id)
+
     def acquire_ref(self, obj_id):
         """
         Add the given ID to the set of objects that we want to acquire.

--- a/calico/felix/test/test_ipsets.py
+++ b/calico/felix/test/test_ipsets.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+felix.test.test_ipsets
+~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for the IpsetManager.
+"""
+
+import logging
+from mock import *
+from calico.datamodel_v1 import EndpointId
+from calico.felix.futils import IPV4
+from calico.felix.ipsets import IpsetManager
+from calico.felix.test.base import BaseTestCase
+
+
+# Logger
+log = logging.getLogger(__name__)
+
+
+EP_ID_1_1 = EndpointId("host1", "orch", "wl1_1", "ep1_1")
+EP_1_1 = {
+    "profile_ids": ["prof1", "prof2"],
+    "ipv4_nets": ["10.0.0.1/32"],
+}
+EP_1_1_NEW_IP = {
+    "profile_ids": ["prof1", "prof2"],
+    "ipv4_nets": ["10.0.0.2/32", "10.0.0.3/32"],
+}
+EP_1_1_NEW_PROF_IP = {
+    "profile_ids": ["prof3"],
+    "ipv4_nets": ["10.0.0.3/32"],
+}
+EP_ID_1_2 = EndpointId("host1", "orch", "wl1_2", "ep1_2")
+EP_ID_2_1 = EndpointId("host2", "orch", "wl2_1", "ep2_1")
+EP_2_1 = {
+    "profile_ids": ["prof1"],
+    "ipv4_nets": ["10.0.0.1/32"],
+}
+
+
+class TestIpsetManager(BaseTestCase):
+    def setUp(self):
+        super(TestIpsetManager, self).setUp()
+        self.reset()
+
+    def reset(self):
+        self.mgr = IpsetManager(IPV4)
+        self.m_create = Mock(spec=self.mgr._create)
+        self.mgr._create = self.m_create
+
+    def test_tag_then_enpdpoint(self):
+        # Send in the messages.
+        self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+        # Let the actor process them.
+        self.step_mgr()
+        self.assert_one_ep_one_tag()
+
+    def test_endpoint_then_tag(self):
+        # Send in the messages.
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+        self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+        # Let the actor process them.
+        self.step_mgr()
+        self.assert_one_ep_one_tag()
+
+    def test_endpoint_then_tag_idempotent(self):
+        for _ in xrange(3):
+            # Send in the messages.
+            self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+            self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+            # Let the actor process them.
+            self.step_mgr()
+            self.assert_one_ep_one_tag()
+
+    def assert_one_ep_one_tag(self):
+        self.assertEqual(self.mgr.endpoints_by_ep_id, {
+            EP_ID_1_1: EP_1_1,
+        })
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag1": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1
+                    ])
+                }
+            }
+        })
+
+    def test_change_ip(self):
+        # Initial set-up.
+        self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+        self.step_mgr()
+        # Update the endpoint's IPs:
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1_NEW_IP, async=True)
+        self.step_mgr()
+
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag1": {
+                "10.0.0.2": {
+                    "prof1": set([
+                        EP_ID_1_1
+                    ])
+                },
+                "10.0.0.3": {
+                    "prof1": set([
+                        EP_ID_1_1
+                    ])
+                }
+            }
+        })
+
+    def test_tag_updates(self):
+        # Initial set-up.
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+        self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+        self.step_mgr()
+
+        # Add a tag, keep a tag.
+        self.mgr.on_tags_update("prof1", ["tag1", "tag2"], async=True)
+        self.step_mgr()
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag1": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1
+                    ])
+                }
+            },
+            "tag2": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1
+                    ])
+                }
+            }
+        })
+        self.assertEqual(self.mgr.tags_by_prof_id, {"prof1": ["tag1", "tag2"]})
+
+        # Remove a tag.
+        self.mgr.on_tags_update("prof1", ["tag2"], async=True)
+        self.step_mgr()
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag2": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1
+                    ])
+                }
+            }
+        })
+
+        # Delete the tags:
+        self.mgr.on_tags_update("prof1", None, async=True)
+        self.step_mgr()
+        self.assertEqual(self.mgr.ip_owners_by_tag, {})
+        self.assertEqual(self.mgr.tags_by_prof_id, {})
+
+    def step_mgr(self):
+        self.step_actor(self.mgr)
+        self.assertEqual(self.mgr._dirty_tags, set())
+
+    def test_update_profile_and_ips(self):
+        # Initial set-up.
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+        self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+        self.mgr.on_tags_update("prof3", ["tag3"], async=True)
+        self.step_mgr()
+
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1_NEW_PROF_IP, async=True)
+        self.step_mgr()
+
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag3": {
+                "10.0.0.3": {
+                    "prof3": set([
+                        EP_ID_1_1
+                    ])
+                }
+            }
+        })
+        self.assertEqual(self.mgr.endpoint_ids_by_profile_id, {
+            "prof3": set([EP_ID_1_1])
+        })
+
+    def test_duplicate_ips(self):
+        # Add in two endpoints with the same IP.
+        self.mgr.on_tags_update("prof1", ["tag1"], async=True)
+        self.mgr.on_endpoint_update(EP_ID_1_1, EP_1_1, async=True)
+        self.mgr.on_endpoint_update(EP_ID_2_1, EP_2_1, async=True)
+        self.step_mgr()
+        # Index should contain both:
+        self.assertEqual(self.mgr.endpoints_by_ep_id, {
+            EP_ID_1_1: EP_1_1,
+            EP_ID_2_1: EP_2_1,
+        })
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag1": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1,
+                        EP_ID_2_1,
+                    ])
+                }
+            }
+        })
+
+        # Second profile tags arrive:
+        self.mgr.on_tags_update("prof2", ["tag1", "tag2"], async=True)
+        self.step_mgr()
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag1": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1,
+                        EP_ID_2_1,
+                    ]),
+                    "prof2": set([
+                        EP_ID_1_1,
+                    ])
+                }
+            },
+            "tag2": {
+                "10.0.0.1": {
+                    "prof2": set([
+                        EP_ID_1_1,
+                    ])
+                }
+            },
+        })
+
+        # Remove one, check the index gets updated.
+        self.mgr.on_endpoint_update(EP_ID_2_1, None, async=True)
+        self.step_mgr()
+        self.assertEqual(self.mgr.endpoints_by_ep_id, {
+            EP_ID_1_1: EP_1_1,
+        })
+        self.assertEqual(self.mgr.ip_owners_by_tag, {
+            "tag1": {
+                "10.0.0.1": {
+                    "prof1": set([
+                        EP_ID_1_1,
+                    ]),
+                    "prof2": set([
+                        EP_ID_1_1,
+                    ])
+                }
+            },
+            "tag2": {
+                "10.0.0.1": {
+                    "prof2": set([
+                        EP_ID_1_1,
+                    ])
+                }
+            },
+        })
+
+        # Remove the other, index should get completely cleaned up.
+        self.mgr.on_endpoint_update(EP_ID_1_1, None, async=True)
+        self.step_mgr()
+        self.assertEqual(self.mgr.endpoints_by_ep_id, {})
+        self.assertEqual(self.mgr.ip_owners_by_tag, {})
+

--- a/docs/source/etcd-data-model.rst
+++ b/docs/source/etcd-data-model.rst
@@ -257,9 +257,7 @@ integer. Because etcd does not have typed data, the data is technically a
 base-10 integer string: writing any other data into this key is an error.
 
 Changes to this key must *always* be performed using etcd's atomic
-compare-and-swap function, including writing it at profile creation time. If a
-control-plane component compares-and-swaps this key down to ``0``, it must then
-issue an etcd delete of the profile directory.
+compare-and-swap function, including writing it at profile creation time.
 
 Care must be taken here: it's possible that an attempt to increment the
 reference count of a profile will find that the profile does not exist


### PR DESCRIPTION
* Profiles are executed in order.  First accept or deny wins.
* The default if there is no match is to drop the packet.
* Single-profile case passed some basic FVs.

Caveats:

* Since we need to return from a chain rather than accept,
  and we need to distinguish explicit return the implicit
  end-of-chain return.  I have used the MARK action to
  distinguish the cases.
* The combination of anti-spoof and profile dispatch in the
  from-endpoint chains is now suboptimal (3nm rules, where
  we could do n+3m instead).
* The tag index is now 4 levels deep which would be a problem
  if we had an endpoint with many IPs, many profiles and
  many tags per profile.  This could be decomposed into
  multiple smaller indices.