### PR TITLE
Fix reference leak in felix caused by reference cycle.

### DIFF
--- a/calico/felix/actor.py
+++ b/calico/felix/actor.py
@@ -436,7 +436,8 @@ def actor_message(needs_own_batch=False):
 
             # OK, so build the message and put it on the queue.
             partial = functools.partial(fn, self, *args, **kwargs)
-            result = TrackedAsyncResult((caller, self.name, method_name))
+            result = TrackedAsyncResult((calling_path, caller,
+                                         self.name, method_name))
             msg = Message(partial, [result], caller, self.name,
                           needs_own_batch=needs_own_batch)
 

--- a/calico/felix/test/base.py
+++ b/calico/felix/test/base.py
@@ -21,8 +21,8 @@ class BaseTestCase(unittest.TestCase):
         self._m_exit = self._exit_patch.start()
 
     def tearDown(self):
-        self._exit_patch.stop()
         self.assertFalse(self._m_exit.called)
+        self._exit_patch.stop()
 
     def step_actor(self, actor):
         self.assertFalse(actor._event_queue.empty())

--- a/calico/felix/test/test_actor.py
+++ b/calico/felix/test/test_actor.py
@@ -224,27 +224,27 @@ class TestExceptionTracking(BaseTestCase):
 
     @mock.patch("calico.felix.actor._print_to_stderr", autospec=True)
     def test_exception(self, _print):
-        num_refs_at_start = len(actor._refs)
+        num_refs_at_start = len(actor._tracked_refs_by_idx)
         ar = actor.TrackedAsyncResult("foo")
         ar.set_exception(Exception())
-        self.assertEqual(num_refs_at_start + 1, len(actor._refs))
+        self.assertEqual(num_refs_at_start + 1, len(actor._tracked_refs_by_idx))
         del ar  # Enough to trigger cleanup in CPython, with exact ref counts.
         self._m_exit.assert_called_once_with(1)
         self.assertTrue(_print.called)
         self.assertTrue("foo" in _print.call_args[0][0])
         self._m_exit.reset_mock()
-        num_refs_at_end = len(actor._refs)
+        num_refs_at_end = len(actor._tracked_refs_by_idx)
         self.assertEqual(num_refs_at_start, num_refs_at_end)
 
     @mock.patch("calico.felix.actor._print_to_stderr", autospec=True)
     def test_no_exception(self, m_print):
-        num_refs_at_start = len(actor._refs)
+        num_refs_at_start = len(actor._tracked_refs_by_idx)
         ar = actor.TrackedAsyncResult("foo")
         ar.set("foo")
         del ar  # Enough to trigger cleanup in CPython, with exact ref counts.
         self.assertFalse(self._m_exit.called)
         self.assertFalse(m_print.called)
-        num_refs_at_end = len(actor._refs)
+        num_refs_at_end = len(actor._tracked_refs_by_idx)
         self.assertEqual(num_refs_at_start, num_refs_at_end)
 
 


### PR DESCRIPTION
Stop attaching the message to the ExceptionTrackingRef beause it indirectly holds a reference to the TrackedAsyncResult.