### PR TITLE
Mock out gethostbyname so we don't have to wait for timeouts during UTs.

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -328,7 +328,7 @@ class Config(object):
         else:
             # Metadata must be supplied as IP or address, but we store as IP
             self.METADATA_IP = self._validate_addr("MetadataAddr",
-                                                  self.METADATA_IP)
+                                                   self.METADATA_IP)
 
             if not common.validate_port(self.METADATA_PORT):
                 raise ConfigException("Invalid field value",


### PR DESCRIPTION
The felix UTs used to take 60s to run, turned out it was really calling gethostbyname(), which has a long timeout.  Mock that out.