### PR TITLE
Avoid excessive processing during endpoint creation.

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -257,13 +257,14 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             port = self.db.get_port(context._plugin_context, port['id'])
 
             # Now, fork execution based on the type of update we're performing.
-            # There are a few: first, a port becoming bound (binding vif_type
-            # from unbound to bound); second, a port becoming unbound (binding
-            # vif_type from bound to unbound); third, an Icehouse migration
-            # (binding host id changed and port bound); fourth, an updated
-            # (port bound at all times); fifth, a change to an unbound port
-            # (which we don't care about, because we do nothing with unbound
-            # ports).
+            # There are a few:
+            # - a port becoming bound (binding vif_type from unbound to bound);
+            # - a port becoming unbound (binding vif_type from bound to
+            #   unbound);
+            # - an Icehouse migration (binding host id changed and port bound);
+            # - an update (port bound at all times);
+            # - a change to an unbound port (which we don't care about, because
+            #   we do nothing with unbound ports).
             if port_bound(port) and not port_bound(original):
                 self._port_bound_update(context, port)
             elif port_bound(original) and not port_bound(port):

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -195,6 +195,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         # If the port binding VIF type is 'unbound', this port doesn't actually
         # need to be networked yet. We can simply return immediately.
         if port['binding:vif_type'] == 'unbound':
+            LOG.info("Creating unbound port: no work required.")
             return
 
         with context._plugin_context.session.begin(subtransactions=True):

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -48,7 +48,8 @@ port1 = {'binding:vif_type': 'tap',
                         'ip_address': '10.65.0.2'}],
          'mac_address': '00:11:22:33:44:55',
          'admin_state_up': True,
-         'security_groups': ['SGID-default']}
+         'security_groups': ['SGID-default'],
+         'status': 'ACTIVE'}
 
 port2 = {'binding:vif_type': 'tap',
          'binding:host_id': 'felix-host-1',
@@ -59,7 +60,8 @@ port2 = {'binding:vif_type': 'tap',
                         'ip_address': '10.65.0.3'}],
          'mac_address': '00:11:22:33:44:66',
          'admin_state_up': True,
-         'security_groups': ['SGID-default']}
+         'security_groups': ['SGID-default'],
+         'status': 'ACTIVE'}
 
 # Port with an IPv6 address.
 port3 = {'binding:vif_type': 'tap',
@@ -71,7 +73,8 @@ port3 = {'binding:vif_type': 'tap',
                         'ip_address': '2001:db8:a41:2::12'}],
          'mac_address': '00:11:22:33:44:66',
          'admin_state_up': True,
-         'security_groups': ['SGID-default']}
+         'security_groups': ['SGID-default'],
+         'status': 'ACTIVE'}
 
 
 # Define a stub class, that we will use as the base class for

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -486,6 +486,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
                 ["SG-1"]
         }
         self.assertEtcdWrites(expected_writes)
+        self.check_update_port_status_called(context)
 
 
         # Resync with all latest data - expect no etcd writes or deletes.


### PR DESCRIPTION
As noticed in #515, during endpoint creation events we can actually end up processing three events and doing three times the work we need to do. The flow is as follows:

1. create_port_postcommit is called, which writes state into etcd. At the end of its processing it updates the port status to ACTIVE, which causes...
2. update_port_postcommit is called, with the port binding VIF type set to unbound. This causes us to (mistakenly) interpret it as the first step of a migration, which causes us to *delete* the state we just wrote to etcd. Subsequently, the binding gets bound, at which point...
3. update_port_postcommit is called *again*, this time with the port bound, which we interpret as the second step of a migration, where we re-create the port.

In practice, the end result of this is actually right, but it causes us to take out two database transactions (including some heavy write locks on MySQL) where we could avoid the majority of them.

This change reduces the work we do, but it's a bit speculative and needs some testing. It's made up of a few observations:

1. If we're asked to create a port, we shouldn't bother with it if the port is unbound, as unbound ports cannot possibly expect connectivity.
2. If we're updating a port, and the only change in it is the port state (ACTIVE->DOWN or DOWN->ACTIVE), we don't want to bother doing anything (nothing we record has actually changed).
3. If we're updating a port we need to check whether the binding state has changed: if it has, we may need to delete it or create it.

I have a follow-on question: with this change, do we still need the non-Icehouse migration steps? I *suspect* that we actually can't hit them now (they'll be two separate `self._update_port` calls), in which case we can actually safely remove them entirely.