### PR TITLE
Force lookup of security group bindings

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -200,6 +200,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             # Next, fill out other information we need on the port.
             self.add_port_gateways(port, context._plugin_context)
             self.add_port_interface_name(port)
+            port['security_groups'] = self.get_security_groups_for_port(
+                context._plugin_context, port
+            )
 
             # Next, we need to work out what security profiles apply to this
             # port and grab information about it.
@@ -325,6 +328,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             port = self.db.get_port(context._plugin_context, port['id'])
             self.add_port_gateways(port, context._plugin_context)
             self.add_port_interface_name(port)
+            port['security_groups'] = self.get_security_groups_for_port(
+                context._plugin_context, port
+            )
             profiles = self.get_security_profiles(
                 context._plugin_context, port
             )
@@ -349,6 +355,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             port = self.db.get_port(context._plugin_context, port['id'])
             self.add_port_gateways(port, context._plugin_context)
             self.add_port_interface_name(port)
+            port['security_groups'] = self.get_security_groups_for_port(
+                context._plugin_context, port
+            )
             profiles = self.get_security_profiles(
                 context._plugin_context, port
             )
@@ -369,6 +378,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             port = self.db.get_port(context._plugin_context, port['id'])
             self.add_port_gateways(port, context._plugin_context)
             self.add_port_interface_name(port)
+            port['security_groups'] = self.get_security_groups_for_port(
+                context._plugin_context, port
+            )
             profiles = self.get_security_profiles(
                 context._plugin_context, port
             )
@@ -529,6 +541,9 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 # etcd.
                 self.add_port_gateways(port, context)
                 self.add_port_interface_name(port)
+                port['security_groups'] = self.get_security_groups_for_port(
+                    context._plugin_context, port
+                )
                 self.transport.endpoint_created(port)
 
     def resync_profiles(self, context):
@@ -602,6 +617,20 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             if start_flag:
                 agent_state['start_flag'] = True
             self.db.create_or_update_agent(db_context, agent_state)
+
+    def get_security_groups_for_port(self, context, port):
+        """
+        Checks which security groups apply for a given port.
+
+        Frustratingly, the port dict provided to us when we call get_port may
+        actually be out of date, and I don't know why. This change ensures that
+        we get the most recent information.
+        """
+        filters = {'port_id': [port['id']]}
+        bindings = self.db._get_port_security_group_bindings(
+            context, filters=filters
+        )
+        return [binding['security_group_id'] for binding in bindings]
 
 
 class CalicoNotifierProxy(object):

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -542,7 +542,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 self.add_port_gateways(port, context)
                 self.add_port_interface_name(port)
                 port['security_groups'] = self.get_security_groups_for_port(
-                    context._plugin_context, port
+                    context, port
                 )
                 self.transport.endpoint_created(port)
 

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -122,6 +122,7 @@ class CalicoTransportEtcd(object):
         """
         Delete data from etcd for an endpoint deleted event.
         """
+        LOG.info("Deleting port %s", port)
         # TODO: What do we do about profiles here?
         # Delete the etcd key for this endpoint.
         key = port_etcd_key(port)

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -203,9 +203,15 @@ class Lib(object):
               'port_range_min': -1}
         ]
 
-        # Prep a null response to the following
-        # _get_port_security_group_bindings call.
-        self.db._get_port_security_group_bindings.return_value = []
+        self.db._get_port_security_group_bindings.side_effect = (
+            self.get_port_security_group_bindings
+        )
+
+        self.port_security_group_bindings = [
+            {'port_id': 'DEADBEEF-1234-5678', 'security_group_id': 'SGID-default'},
+            {'port_id': 'FACEBEEF-1234-5678', 'security_group_id': 'SGID-default'},
+            {'port_id': 'HELLO-1234-5678', 'security_group_id': 'SGID-default'},
+        ]
 
     def setUp_eventlet(self):
         """Setup to intercept sleep calls made by the code under test, and hence to
@@ -389,3 +395,13 @@ class Lib(object):
             self.db.notifier.security_groups_member_updated(
                 mock.MagicMock(), [id]
             )
+
+    def get_port_security_group_bindings(self, context, filters):
+        if filters is None:
+            return self.port_security_group_bindings
+
+        assert filters.keys() == ['port_id']
+        allowed_ids = set(filters['port_id'])
+
+        return [b for b in self.port_security_group_bindings
+                if b['port_id'] in allowed_ids]

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -466,7 +466,10 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
 
         # Now change the security group for that port.
         context.original = context._port.copy()
-        context._port['security_groups'] = ['SG-1']
+        self.port_security_group_bindings.pop(2)
+        self.port_security_group_bindings.append({
+            'port_id': 'HELLO-1234-5678', 'security_group_id': 'SG-1'
+        })
         self.driver.update_port_postcommit(context)
         expected_writes = {
             '/calico/v1/host/felix-host-2/workload/openstack/instance-3/endpoint/HELLO-1234-5678':


### PR DESCRIPTION
This guarantees that we have up-to-date security group information. For some reason unbeknownst to me, the `get_port` call does not actually return up-to-date information. This change instead forcibly looks up the security group port binding table, which is actually accurate.