### PR TITLE
Don't exit because we failed to remain master

### DIFF
--- a/calico/election.py
+++ b/calico/election.py
@@ -203,7 +203,9 @@ class Elector(object):
                 # This is a pretty broad except statement, but anything going
                 # wrong means this instance gives up being the master.
                 self._master = False
-                raise
+                _log.warning("Failed to renew master role - key %s",
+                             self._key, exc_info=True)
+                raise ElectionReconnect()
 
     def master(self):
         """


### PR DESCRIPTION
The election code handles all cases but this one: failing to remain the master is not a justification for giving up on the election. Instead, treat it the same as failing to *become* the master: stop being master and rejoin the election.

Resolves #543.