### PR TITLE
Start periodic resync thread from initialisation rather than vice versa.

### DIFF
--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -317,6 +317,11 @@ class CalicoTransportEtcd(object):
             except etcd.EtcdException as e:
                 LOG.debug("Failed to delete %s (%r), skipping.", delete_key, e)
 
+    def stop(self):
+        LOG.info("Stopping transport %s", self)
+        self.elector.stop()
+
+
 def _neutron_rule_to_etcd_rule(rule):
     """
     Translate a single Neutron rule dict to a single dict in our

--- a/calico/openstack/test/lib.py
+++ b/calico/openstack/test/lib.py
@@ -93,6 +93,9 @@ class GrandDukeOfSalzburg(object):
     def master(self):
         return True
 
+    def stop(self):
+        pass
+
 
 # Replace Neutron's SimpleAgentMechanismDriverBase - which is the base class
 # that CalicoMechanismDriver inherits from - with this stub class.
@@ -274,6 +277,13 @@ class Lib(object):
             # Also return it.
             return thread
 
+        def simulated_spawn_after(secs, fn, *args):
+            def sleep_then_run():
+                simulated_time_sleep(secs)
+                fn(*args)
+
+            return simulated_spawn(sleep_then_run)
+
         # Hook sleeping.
         self.real_eventlet_sleep = eventlet.sleep
         eventlet.sleep = simulated_time_sleep
@@ -281,6 +291,9 @@ class Lib(object):
         # Similarly hook spawning.
         self.real_eventlet_spawn = eventlet.spawn
         eventlet.spawn = simulated_spawn
+
+        self.real_eventlet_spawn_after = eventlet.spawn_after
+        eventlet.spawn_after = simulated_spawn_after
 
     def setUp_logging(self):
         """Setup to intercept and display logging by the code under test.
@@ -305,6 +318,7 @@ class Lib(object):
         # Restore the real eventlet.sleep and eventlet.spawn.
         eventlet.sleep = self.real_eventlet_sleep
         eventlet.spawn = self.real_eventlet_spawn
+        eventlet.spawn_after = self.real_eventlet_spawn_after
 
     # Method for the test code to call when it wants to advance the simulated
     # time.


### PR DESCRIPTION
* Resync thread was only running in the parent process.
* But Electors got started lazily in the children.
* If parent didn't win the election, periodic resync didn't
  happen.

This change:

* Starts the periodic resync lazily.
* Defensively checks the PID and re-initialises everything if
  it changes.
* Adds the ability to stop the Elector so we can recreate it.

Fixes #550 