### PR TITLE
Various fixes found through manual FV

### DIFF
--- a/calico/election.py
+++ b/calico/election.py
@@ -173,7 +173,7 @@ class Elector(object):
             self._etcd_client.write(self._key,
                                     self.id_string,
                                     ttl=self._ttl,
-                                    prevExists=False,
+                                    prevExist=False,
                                     timeout=self._interval)
         except Exception as e:
             # We could be smarter about what exceptions we allow, but any kind

--- a/calico/test/stub_etcd.py
+++ b/calico/test/stub_etcd.py
@@ -28,13 +28,13 @@ log = logging.getLogger(__name__)
 class EtcdException(Exception):
     pass
 
-class EtcdKeyNotFound(Exception):
+class EtcdKeyNotFound(EtcdException):
     pass
 
-class EtcdClusterIdChanged(Exception):
+class EtcdClusterIdChanged(EtcdException):
     pass
 
-class EtcdEventIndexCleared(Exception):
+class EtcdEventIndexCleared(EtcdException):
     pass
 
 class NoMoreResults(Exception):

--- a/calico/test/test_election.py
+++ b/calico/test/test_election.py
@@ -77,131 +77,121 @@ class TestElection(unittest.TestCase):
             elector = election.Elector(client, "test_basic", "/bloop", interval=10, ttl=5)
             self.assertFalse(elector.master())
 
+    def _wait_and_stop(self, client, elector):
+        # Wait for the client to tell us that all the results have been
+        # processed.
+        eventlet.with_timeout(5, client.no_more_results.wait)
+        # This should shut down the Elector.
+        eventlet.with_timeout(5, elector.stop)
+        # The greenlet should be dead already, but just in case, let our
+        # client proceed to raise its exception.
+        client.stop.send()
+        # Double-check there were no failures.
+        self.assertEqual(client.failure, None, msg=client.failure)
+
     def test_basic_election(self):
         # Test that not elected using defaults.
         log.debug("test_basic_election")
-        try:
-            client = stub_etcd.Client()
-            client.add_read_result(key="/bloop", value="value")
-            elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
-            elector._greenlet.wait()
-        except NoMoreResults:
-            pass
-        master = elector.master()
+        client = stub_etcd.Client()
+        client.add_read_result(key="/bloop", value="value")
+        elector = election.Elector(client, "test_basic", "/bloop",
+                                   interval=5, ttl=15)
+        self._wait_and_stop(client, elector)
         self.assertFalse(elector.master())
 
     def test_become_master_first_time(self):
         # Become the master after once round
         log.debug("test_become_master_first_time")
-        try:
-            client = stub_etcd.Client()
-            client.add_read_exception(stub_etcd.EtcdKeyNotFound())
-            client.add_write_exception(None)
-            client.add_write_exception(None)
-            elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
-            elector._greenlet.wait()
-        except NoMoreResults:
-            pass
+        client = stub_etcd.Client()
+        client.add_read_exception(stub_etcd.EtcdKeyNotFound())
+        client.add_write_exception(None)
+        client.add_write_exception(None)
+        elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
+        self._wait_and_stop(client, elector)
 
     def test_become_master_multiple_attempts(self):
         # Become the master after once round
         log.debug("test_become_master_multiple_circuits")
         for action in ["delete", "expire", "compareAndDelete", "something"]:
-            try:
-                log.info("Testing etcd delete event %s", action)
-                client = stub_etcd.Client()
-                client.add_read_result(key="/bloop", value="value")
-                client.add_read_result(key="/bloop", value="value")
-                client.add_read_result(key="/bloop", value=None, action=action)
-                client.add_write_exception(None)
-                client.add_write_exception(None)
-                elector = election.Elector(client, "test_basic", "/bloop",
-                                           interval=5, ttl=15)
-                elector._greenlet.wait()
-            except NoMoreResults:
-                pass
+            log.info("Testing etcd delete event %s", action)
+            client = stub_etcd.Client()
+            client.add_read_result(key="/bloop", value="value")
+            client.add_read_result(key="/bloop", value="value")
+            client.add_read_result(key="/bloop", value=None, action=action)
+            client.add_write_exception(None)
+            client.add_write_exception(None)
+            elector = election.Elector(client, "test_basic", "/bloop",
+                                       interval=5, ttl=15)
+            self._wait_and_stop(client, elector)
 
     def test_become_master_implausible(self):
         # Become the master after key vanishes
         log.debug("test_become_master_implausible")
-        try:
-            client = stub_etcd.Client()
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(stub_etcd.EtcdKeyNotFound())
-            client.add_write_result()
-            client.add_write_result()
-            elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
-            elector._greenlet.wait()
-        except NoMoreResults:
-            pass
+        client = stub_etcd.Client()
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(stub_etcd.EtcdKeyNotFound())
+        client.add_write_result()
+        client.add_write_result()
+        elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
+        self._wait_and_stop(client, elector)
 
     def test_initial_read_exceptions(self):
         log.debug("test_initial_read_exceptions")
 
-        try:
-            client = stub_etcd.Client()
-            client.add_read_exception(stub_etcd.EtcdException())
-            client.add_read_exception(ReadTimeoutError("pool", "url", "message"))
-            client.add_read_exception(SocketTimeout())
-            client.add_read_exception(ConnectTimeoutError())
-            client.add_read_exception(HTTPError())
-            client.add_read_exception(HTTPException())
-            client.add_read_exception(stub_etcd.EtcdClusterIdChanged())
-            client.add_read_exception(stub_etcd.EtcdEventIndexCleared())
-            elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
-            elector._greenlet.wait()
-        except NoMoreResults:
-            pass
-
+        client = stub_etcd.Client()
+        client.add_read_exception(stub_etcd.EtcdException())
+        client.add_read_exception(ReadTimeoutError("pool", "url", "message"))
+        client.add_read_exception(SocketTimeout())
+        client.add_read_exception(ConnectTimeoutError())
+        client.add_read_exception(HTTPError())
+        client.add_read_exception(HTTPException())
+        client.add_read_exception(stub_etcd.EtcdClusterIdChanged())
+        client.add_read_exception(stub_etcd.EtcdEventIndexCleared())
+        elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
+        self._wait_and_stop(client, elector)
 
     def test_later_exceptions(self):
         log.debug("test_later_read_exceptions")
 
-        try:
-            client = stub_etcd.Client()
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(stub_etcd.EtcdException())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(ReadTimeoutError("pool", "url", "message"))
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(SocketTimeout())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(ConnectTimeoutError())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(HTTPError())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(HTTPException())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(stub_etcd.EtcdClusterIdChanged())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_exception(stub_etcd.EtcdEventIndexCleared())
-            elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
-            elector._greenlet.wait()
-        except NoMoreResults:
-            pass
+        client = stub_etcd.Client()
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(stub_etcd.EtcdException())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(ReadTimeoutError("pool", "url", "message"))
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(SocketTimeout())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(ConnectTimeoutError())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(HTTPError())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(HTTPException())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(stub_etcd.EtcdClusterIdChanged())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_exception(stub_etcd.EtcdEventIndexCleared())
+        elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
+        self._wait_and_stop(client, elector)
 
     def test_master_failure(self):
         log.debug("test_master_failure")
 
-        try:
-            client = stub_etcd.Client()
-            client.add_read_exception(stub_etcd.EtcdKeyNotFound())
-            # Now become the master but fail
-            client.add_write_exception(stub_etcd.EtcdException())
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_result(key="/bloop", value=None, action="delete")
-            # Now become the master but fail again
-            client.add_write_exception(stub_etcd.EtcdException())
-            # Go back to the beginning again.
-            client.add_read_result(key="/bloop", value="value")
-            client.add_read_result(key="/bloop", value=None, action="delete")
-            client.add_write_exception(None)
-            client.add_write_exception(None)
-            elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
-            elector._greenlet.wait()
-        except NoMoreResults:
-            pass
+        client = stub_etcd.Client()
+        client.add_read_exception(stub_etcd.EtcdKeyNotFound())
+        # Now become the master but fail
+        client.add_write_exception(stub_etcd.EtcdException())
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_result(key="/bloop", value=None, action="delete")
+        # Now become the master but fail again
+        client.add_write_exception(stub_etcd.EtcdException())
+        # Go back to the beginning again.
+        client.add_read_result(key="/bloop", value="value")
+        client.add_read_result(key="/bloop", value=None, action="delete")
+        client.add_write_exception(None)
+        client.add_write_exception(None)
+        elector = election.Elector(client, "test_basic", "/bloop", interval=5, ttl=15)
+        self._wait_and_stop(client, elector)
 
         # We are no longer the master, after error.
         self.assertFalse(elector.master())


### PR DESCRIPTION
Started off just fixing #556 and #557 but found a few more issues while I was doing manual FV of those changes:

* Reinit client and elector after EtcdException in mechanism driver (including EtcdClusterIdChanged).
* Have Elector forcefully shut down its greenlet to avoid temporary overlap with dying greenlet.  Use the stop mechanism in the UTs to give it a workout.
* Use decorator to handle exception in each transport API call.
* Simplify exception handling in Elector (seemed odd that we were catching EtcdException and EtcdFooException, which is a subclass -- maybe an artefact of our stub missing this detail?)
* Reduce log verbosity on somewhat-expected failures by feeding exceptions through common logging function (I know at least one customer who might see all the tracebacks as a regression).
* Reduce and randomise the retry timer.  It was taking minutes to even retry in my testing.
* Fix prevExists/prevExist incorrect API call to python-etcd.

Fixes #556 #557.