### PR TITLE
Only kill the elector greenlet if it is running.  Fix kill args.

### DIFF
--- a/calico/election.py
+++ b/calico/election.py
@@ -254,8 +254,8 @@ class Elector(object):
 
     def stop(self):
         self._stopped = True
-        if not self._greenlet.dead:
-            self._greenlet.kill(ElectorStopped())
+        if self._greenlet and not self._greenlet.dead:
+            self._greenlet.kill(ElectorStopped(), None, None)
             try:
                 # It should die very quickly.
                 eventlet.with_timeout(10, self._greenlet.wait)

--- a/calico/test/test_election.py
+++ b/calico/test/test_election.py
@@ -85,6 +85,7 @@ class TestElection(unittest.TestCase):
         except eventlet.Timeout:
             elector._greenlet.kill(AssertionError("Didn't reach end of results"))
             elector._greenlet.wait()
+            raise
         # This should shut down the Elector.
         eventlet.with_timeout(5, elector.stop)
         # The greenlet should be dead already, but just in case, let our


### PR DESCRIPTION
Fixes #578 