### PR TITLE
Fix incorrect underline build warning in docs

### DIFF
--- a/docs/source/involved.rst
+++ b/docs/source/involved.rst
@@ -22,7 +22,7 @@ the options for getting involved with Calico the project, please take a look at
 the following.
 
 Mailing Lists
-------------
+-------------
 Project Calico runs two mailing lists:
 
 -  `calico-announce <http://lists.projectcalico.org/listinfo/calico-announce>`__


### PR DESCRIPTION
Incorrect length underline is causing a build warning in our docs.