### PR TITLE
Increase number of file descriptors in calico-felix.conf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   interfaces.
 - Prevent the possibility of gevent context-switching during garbage collection
   in Felix
+- Increase the number of file descriptors available to Felix
 
 ## 0.21
 

--- a/debian/calico-felix.upstart
+++ b/debian/calico-felix.upstart
@@ -5,6 +5,8 @@ author "Project Calico Maintainers <maintainers@projectcalico.org>"
 start on stopped rc RUNLEVEL=[2345]
 stop on runlevel [!2345]
 
+limit nofile 32000 32000
+
 respawn
 
 chdir /var/run

--- a/rpm/calico-felix.conf
+++ b/rpm/calico-felix.conf
@@ -3,6 +3,8 @@ description "Calico Felix Agent"
 start on stopped rc RUNLEVEL=[2345]
 stop on runlevel [!2345]
 
+limit nofile 32000 32000
+
 respawn
 
 pre-start script

--- a/rpm/calico-felix.service
+++ b/rpm/calico-felix.service
@@ -9,6 +9,7 @@ ExecStartPre=/usr/bin/mkdir -p /var/run/calico
 ExecStart=/usr/bin/calico-felix --config-file=/etc/calico/felix.cfg
 KillMode=process
 Restart=always
+LimitNOFILE=32000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This increases the number of file descriptors available to Felix, which should mitigate issue #534 (Felix gets sad when it can't create any more VMs/tap interfaces).

I picked 32K just because it was the first number suggested in that issue. We don't have any documentation for editing calico-felix.conf, so I assume it gets put in place by our installers. This is the only felix.conf file in the /calico repo, so I'm guessing this is it.