### PR TITLE
Migrate to oslo logging when needed.

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -211,7 +211,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         # We override this primarily to satisfy the ABC checker: this method
         # never actually gets called because we also override
         # check_segment_for_agent.
-        return agent['configurations'].get('interface_mappings', {})
+        assert False
 
     def _port_is_endpoint_port(self, port):
         # Return True if port is a VM port.

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -31,11 +31,15 @@ from functools import wraps
 
 # OpenStack imports.
 from neutron.common import constants
-from neutron.openstack.common import log
 from neutron.plugins.ml2 import driver_api as api
 from neutron.plugins.ml2.drivers import mech_agent
 from neutron import context as ctx
 from neutron import manager
+
+try:  # Icehouse, Juno
+    from neutron.openstack.common import log
+except ImportError:  # Kilo
+    from oslo_log import log
 
 # Calico imports.
 import etcd

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -204,6 +204,15 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         else:
             return False
 
+    def get_allowed_network_types(self, agent=None):
+        return ('local', 'flat')
+
+    def get_mappings(self, agent):
+        # We override this primarily to satisfy the ABC checker: this method
+        # never actually gets called because we also override
+        # check_segment_for_agent.
+        return agent['configurations'].get('interface_mappings', {})
+
     def _port_is_endpoint_port(self, port):
         # Return True if port is a VM port.
         if port['device_owner'].startswith('compute:'):

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -28,7 +28,11 @@ import weakref
 
 # OpenStack imports.
 from oslo.config import cfg
-from neutron.openstack.common import log
+
+try:  # Icehouse, Juno
+    from neutron.openstack.common import log
+except ImportError:  # Kilo
+    from oslo_log import log
 
 # Calico imports.
 from eventlet.semaphore import Semaphore


### PR DESCRIPTION
Seems that Neutron migrated to Oslo logging during the Kilo cycle, which means we need to change our imports.