### PR TITLE
Intern IDs that are likely to be repeated.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Allow different hosts to have different interface prefixes for combined
   OpenStack and Docker systems.
 - Add missing support for 0 as a TCP port.
+- Intern various IDs in felix to reduce occupancy.
 
 ## 0.23
 

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -112,7 +112,36 @@ def get_profile_id_for_profile_dir(key):
     return final_node if prefix == PROFILE_DIR else None
 
 
-class EndpointId(namedtuple("EndpointId", ["host", "orchestrator",
-                                           "workload", "endpoint"])):
+class EndpointId(object):
+    __slots__ = ["host", "orchestrator", "workload", "endpoint"]
+
+    def __init__(self, host, orchestrator, workload, endpoint):
+        # Host and orchestrator can be sensibly interned, they appear
+        # regularly.  They shouldn't contain any utf-8 characters but we get
+        # back a unicode string so encode it.
+        self.host = intern(host.encode("utf8"))
+        self.orchestrator = intern(orchestrator.encode("utf8"))
+        # No sensible interning to be done for workload/endpoint.
+        self.workload = workload.encode("utf8")
+        self.endpoint = endpoint.encode("utf8")
+
     def __str__(self):
-        return self.__class__.__name__ + ("<%s/%s/%s/%s>" % self)
+        return self.__class__.__name__ + ("<%s>" % self.endpoint)
+
+    def __eq__(self, other):
+        if other is self:
+            return True
+        if not isinstance(other, EndpointId):
+            return False
+        if (other.endpoint == self.endpoint and
+                other.workload == self.workload and
+                other.host == self.host and
+                other.orchestrator == self.orchestrator):
+            return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.endpoint) + hash(self.workload)

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -116,14 +116,13 @@ class EndpointId(object):
     __slots__ = ["host", "orchestrator", "workload", "endpoint"]
 
     def __init__(self, host, orchestrator, workload, endpoint):
-        # Host and orchestrator can be sensibly interned, they appear
-        # regularly.  They shouldn't contain any utf-8 characters but we get
-        # back a unicode string so encode it.
+        # We intern these strings since they can occur in many IDs.  The
+        # host and orchestrator are trivially repeated for all endpoints
+        # on a host.  The others get repeated over time.
         self.host = intern(host.encode("utf8"))
         self.orchestrator = intern(orchestrator.encode("utf8"))
-        # No sensible interning to be done for workload/endpoint.
-        self.workload = workload.encode("utf8")
-        self.endpoint = endpoint.encode("utf8")
+        self.workload = intern(workload.encode("utf8"))
+        self.endpoint = intern(endpoint.encode("utf8"))
 
     def __str__(self):
         return self.__class__.__name__ + ("<%s>" % self.endpoint)
@@ -133,12 +132,10 @@ class EndpointId(object):
             return True
         if not isinstance(other, EndpointId):
             return False
-        if (other.endpoint == self.endpoint and
+        return (other.endpoint == self.endpoint and
                 other.workload == self.workload and
                 other.host == self.host and
-                other.orchestrator == self.orchestrator):
-            return True
-        return False
+                other.orchestrator == self.orchestrator)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -26,6 +26,7 @@ import functools
 import hashlib
 import logging
 import os
+from types import StringTypes
 from gevent import subprocess
 import tempfile
 import time
@@ -216,3 +217,46 @@ def logging_exceptions(fn):
             log.exception("Exception in wrapped function %s", fn)
             raise
     return wrapped
+
+
+def intern_dict(d, fields_to_intern=None):
+    """
+    Return a copy of the input dict where all its string/unicode keys
+    are interned, optionally interning some of its values too.
+
+    Caveat: assumes that it is safe to convert the keys and interned values
+    to str by calling .encode("utf8") on each string.
+
+    :param dict[StringTypes,...] d: Input dict.
+    :param set[StringTypes] fields_to_intern: set of field names whose values
+        should also be interned.
+    :return: new dict with interned keys/values.
+    """
+    fields_to_intern = fields_to_intern or set()
+    out = {}
+    for k, v in d.iteritems():
+        # We can't intern unicode strings, as returned by etcd but all our
+        # keys should be ASCII anyway.  Use the utf8 encoding just in case.
+        k = intern(k.encode("utf8"))
+        if k in fields_to_intern:
+            if isinstance(v, StringTypes):
+                v = intern(v.encode("utf8"))
+            elif isinstance(v, list):
+                v = intern_list(v)
+        out[k] = v
+    return out
+
+
+def intern_list(l):
+    """
+    Returns a new list with interned versions of the input list's contents.
+
+    Non-strings are copied to the new list verbatim.  returned strings are e
+    encoded using .encode("utf8").
+    """
+    out = []
+    for item in l:
+        if isinstance(item, StringTypes):
+            item = intern(item.encode("utf8"))
+        out.append(item)
+    return out


### PR DESCRIPTION
@plwhite this one is a bit more speculative.  It interns IDs that I expect to be duplicated a lot (profile IDs and tag IDs get used at least 4-8 times each so that might help quite a bit).  I'd appreciate if you or Alex could pass it through the scale test to see if it helps.

* Intern white-listed fields while parsing JSON dicts and lists.
* Intern EndpointID fields.