### PR TITLE
Limit our shell-out concurrency.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.27-dev
 
+- Limit number of concurrent shell-outs in felix to prevent file descriptor
+  exhaustion.
 - Stop restarting Felix on Ubuntu if it fails more than 5 times in 10 seconds.
 
 ## 0.26

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -27,11 +27,13 @@ import hashlib
 import logging
 import os
 from types import StringTypes
+import gevent.lock
 from gevent import subprocess
 import tempfile
 import time
 
 from collections import namedtuple
+
 CommandOutput = namedtuple('CommandOutput', ['stdout', 'stderr'])
 
 # Logger
@@ -46,6 +48,11 @@ IP_VERSIONS = [4, 6]
 IP_TYPE_TO_VERSION = {IPV4: 4, IPV6: 6}
 
 SHORTENED_PREFIX = "_"
+
+# Semaphore used to limit the number of concurrent shell-outs.  Prevents us
+# from using an unbounded number of file handles for stdin/out/err handling.
+MAX_CONCURRENT_CALLS = 50
+_call_semaphore = gevent.lock.Semaphore(MAX_CONCURRENT_CALLS)
 
 
 class FailedSystemCall(Exception):
@@ -94,14 +101,20 @@ def check_call(args, input_str=None):
     :raises FailedSystemCall: if the return code of the subprocess is non-zero.
     :raises OSError: if, for example, there is a read error on stdout/err.
     """
-    log.debug("Calling out to system : %s" % args)
+    log.debug("Calling out to system : %s.  %s/%s concurrent calls",
+              args,
+              MAX_CONCURRENT_CALLS - _call_semaphore.counter,
+              MAX_CONCURRENT_CALLS)
 
     stdin = subprocess.PIPE if input_str is not None else None
-    proc = subprocess.Popen(args,
-                            stdin=stdin,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    stdout, stderr = proc.communicate(input=input_str)
+
+    with _call_semaphore:
+        proc = subprocess.Popen(args,
+                                stdin=stdin,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate(input=input_str)
+
     retcode = proc.returncode
     if retcode:
         raise FailedSystemCall("Failed system call",

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -51,7 +51,9 @@ SHORTENED_PREFIX = "_"
 
 # Semaphore used to limit the number of concurrent shell-outs.  Prevents us
 # from using an unbounded number of file handles for stdin/out/err handling.
-MAX_CONCURRENT_CALLS = 50
+# Tuning: <10 seemed noticeably worse 20-200 hovered around the same.  Chose
+# a value at low end of that range to limit our impact on the system.
+MAX_CONCURRENT_CALLS = 32
 _call_semaphore = gevent.lock.Semaphore(MAX_CONCURRENT_CALLS)
 
 

--- a/calico/felix/test/test_futils.py
+++ b/calico/felix/test/test_futils.py
@@ -61,13 +61,17 @@ class TestFutils(unittest.TestCase):
         pass
 
     def test_good_check_call(self):
-        # Test a command. Result must include "calico" given where it is run from.
-        args = ["ls"]
-        result = futils.check_call(args)
-        self.assertNotEqual(result.stdout, None)
-        self.assertNotEqual(result.stderr, None)
-        self.assertTrue("calico" in result.stdout)
-        self.assertEqual(result.stderr, "")
+        with mock.patch("calico.felix.futils._call_semaphore",
+                        wraps=futils._call_semaphore) as m_sem:
+            # Test a command. Result must include "calico" given where it is
+            # run from.
+            args = ["ls"]
+            result = futils.check_call(args)
+            self.assertNotEqual(result.stdout, None)
+            self.assertNotEqual(result.stderr, None)
+            self.assertTrue("calico" in result.stdout)
+            self.assertEqual(result.stderr, "")
+            self.assertTrue(m_sem.__enter__.called)
 
     def test_bad_check_call(self):
         # Test an invalid command - must parse but not return anything.


### PR DESCRIPTION
@plwhite another (small) speculative change that might help with the scale testing.  It puts a cap on the number of concurrent `check_call()` calls.  I doubt it's optimal to try to issue 1000 shell-outs at once at start of day so it'd be interesting to run this and tweak the limit to see if it has an impact.
