### PR TITLE
Sprinkle stats counters through felix.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.24-dev
 
+- Add Felix statistics logging on USR1 signal.
 - Add support for routing over IP-in-IP interfaces in order to make it 
   easier to evaluate Calico without reconfiguring underlying network.
 - Reduce felix occupancy by replacing endpoint dictionaries by "struct"

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -21,20 +21,19 @@ The main logic for Felix.
 """
 
 # Monkey-patch before we do anything else...
-import functools
 from gevent import monkey
-import signal
-from calico.felix import futils
-
 monkey.patch_all()
 
+import functools
 import logging
 import optparse
 import os
+import signal
 
 import gevent
 
 from calico import common
+from calico.felix import futils
 from calico.felix.fiptables import IptablesUpdater
 from calico.felix.dispatch import DispatchChains
 from calico.felix.profilerules import RulesManager

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -21,6 +21,7 @@ felix.futils
 
 Felix utilities.
 """
+import collections
 import functools
 import hashlib
 import logging
@@ -163,6 +164,46 @@ def uniquely_shorten(string, length):
     hash_text = h.hexdigest()
 
     return SHORTENED_PREFIX + hash_text[:length-len(SHORTENED_PREFIX)]
+
+
+_registered_diags = []
+
+
+def register_diags(name, fn):
+    _registered_diags.append((name, fn))
+
+
+class StatCounter(object):
+    def __init__(self, name):
+        self.name = name
+        self.stats = collections.defaultdict(lambda: 0)
+        register_diags(name, self._dump)
+
+    def increment(self, stat, by=1):
+        self.stats[stat] += 1
+
+    def _dump(self, log):
+        stats_copy = self.stats.items()
+        for name, stat in sorted(stats_copy):
+            log.info("%s: %s", name, stat)
+
+
+def dump_diags():
+    """
+    Dump diagnostics to the log.
+    """
+    try:
+        log.info("=== DIAGNOSTICS ===")
+        for name, diags_function in _registered_diags:
+            log.info("--- %s ---", name)
+            diags_function(log)
+        log.info("=== END OF DIAGNOSTICS ===")
+    except Exception:
+        # We don't want to take down the process we're trying to diagnose...
+        try:
+            log.exception("Failed to dump diagnostics")
+        except Exception:
+            pass
 
 
 def logging_exceptions(fn):

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -35,6 +35,7 @@ CommandOutput = namedtuple('CommandOutput', ['stdout', 'stderr'])
 
 # Logger
 log = logging.getLogger(__name__)
+stat_log = logging.getLogger("calico.stats")
 
 # Flag to indicate "IP v4" or "IP v6"; format that can be printed in logs.
 IPV4 = "IPv4"
@@ -193,15 +194,15 @@ def dump_diags():
     Dump diagnostics to the log.
     """
     try:
-        log.info("=== DIAGNOSTICS ===")
+        stat_log.info("=== DIAGNOSTICS ===")
         for name, diags_function in _registered_diags:
-            log.info("--- %s ---", name)
-            diags_function(log)
-        log.info("=== END OF DIAGNOSTICS ===")
+            stat_log.info("--- %s ---", name)
+            diags_function(stat_log)
+        stat_log.info("=== END OF DIAGNOSTICS ===")
     except Exception:
         # We don't want to take down the process we're trying to diagnose...
         try:
-            log.exception("Failed to dump diagnostics")
+            stat_log.exception("Failed to dump diagnostics")
         except Exception:
             pass
 


### PR DESCRIPTION
Thought adding some stats to felix might help with general high-level awareness of what's going on in there.

SIGUSR1 triggers a stats dump; which looks like this:
```
2015-06-03 15:53:31,214 [INFO][4854/19] calico.felix.futils 196: === DIAGNOSTICS ===
2015-06-03 15:53:31,214 [INFO][4854/19] calico.felix.futils 198: --- Actor framework counters ---
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Batches processed: 28
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Blocking calls completed: 13
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Blocking calls started: 13
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Messages completed: 30
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Messages created: 32
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Messages executed OK: 30
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 198: --- Actor framework ---
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 493: Current ref index: 32
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 495: Number of tracked messages outstanding: 2
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 198: --- IPv4 filter iptables updater ---
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Batches finished: 6
2015-06-03 15:53:31,215 [INFO][4854/19] calico.felix.futils 188: Chain deletes: 1
2015-06-03 15:53:31,216 [INFO][4854/19] calico.felix.futils 188: Chain rewrites: 2
2015-06-03 15:53:31,216 [INFO][4854/19] calico.felix.futils 188: Cleanups performed: 1
2015-06-03 15:53:31,216 [INFO][4854/19] calico.felix.futils 188: Refreshed chain list: 3
2015-06-03 15:53:31,216 [INFO][4854/19] calico.felix.futils 188: Rule inserts: 2
2015-06-03 15:53:31,216 [INFO][4854/19] calico.felix.futils 188: iptables success: 4
...
```