### PR TITLE
When an IP (or whole endpoint) is removed, remove conntrack entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.25-dev
 
+- Remove stale conntrack entries when an endpoint's IP is removed.
 - Improve security between endpoint and host and simplify INPUT chain logic.
 
 ## 0.24

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -253,12 +253,12 @@ def remove_conntrack_flows(ip_addresses, ip_version):
                     # Expected if there are no flows.
                     _log.debug("No conntrack entries found for %s/%s.",
                                ip, direction)
-                    continue
-                # Suppress the exception, conntrack entries will timeout and
-                # it's hard to think of an example where killing and
-                # restarting felix would help.
-                _log.exception("Failed to remove conntrack flows for %s. "
-                               "Ignoring.", ip)
+                else:
+                    # Suppress the exception, conntrack entries will timeout
+                    # and it's hard to think of an example where killing and
+                    # restarting felix would help.
+                    _log.exception("Failed to remove conntrack flows for %s. "
+                                   "Ignoring.", ip)
 
 
 # These constants map to constants in the Linux kernel. This is a bit poor, but

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -196,8 +196,10 @@ def set_routes(ip_type, ips, interface, mac=None, reset_arp=False):
 
     current_ips = list_interface_ips(ip_type, interface)
 
-    for ip in (current_ips - ips):
+    removed_ips = (current_ips - ips)
+    for ip in removed_ips:
         del_route(ip_type, ip, interface)
+    remove_conntrack_flows(removed_ips, 4 if ip_type == futils.IPV4 else 6)
     for ip in (ips - current_ips):
         add_route(ip_type, ip, interface, mac)
     if reset_arp:
@@ -232,17 +234,20 @@ def interface_up(if_name):
     return bool(int(flags, 16) & 1)
 
 
-def remove_conntrack_flows(ip_addresses):
+def remove_conntrack_flows(ip_addresses, ip_version):
     """
     Removes any conntrack entries that use any of the given IP
     addresses in their source/destination.
     """
+    assert ip_version in (4, 6)
     for ip in ip_addresses:
         _log.debug("Removing conntrack rules for %s", ip)
         for direction in ["--orig-src", "--orig-dst",
                           "--reply-src", "--reply-dst"]:
             try:
-                futils.check_call(["conntrack", "--delete", direction, ip])
+                futils.check_call(["conntrack", "--family",
+                                   "ipv%s" % ip_version, "--delete",
+                                   direction, ip])
             except FailedSystemCall as e:
                 if e.retcode == 1 and "0 flow entries" in e.stderr:
                     # Expected if there are no flows.

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -23,6 +23,7 @@ import logging
 from subprocess import CalledProcessError
 from calico.felix import devices, futils
 from calico.felix.actor import actor_message
+from calico.felix.devices import remove_conntrack_flows
 from calico.felix.futils import FailedSystemCall
 from calico.felix.futils import IPV4
 from calico.felix.refcount import ReferenceManager, RefCountedActor, RefHelper
@@ -189,6 +190,10 @@ class LocalEndpoint(RefCountedActor):
         self.config = config
         self.ip_type = ip_type
         self.ip_version = futils.IP_TYPE_TO_VERSION[ip_type]
+        if self.ip_type == IPV4:
+            self.nets_key = "ipv4_nets"
+        else:
+            self.nets_key = "ipv6_nets"
         self.iptables_updater = iptables_updater
         self.dispatch_chains = dispatch_chains
         self.rules_mgr = rules_manager
@@ -240,14 +245,25 @@ class LocalEndpoint(RefCountedActor):
         # longer need).
         if endpoint:
             new_profile_ids = set(endpoint["profile_ids"])
+            new_ip_nets = set(endpoint.get(self.nets_key, []))
         else:
             new_profile_ids = set()
+            new_ip_nets = set()
         # Note: we don't actually need to wait for the activation to finish
         # due to the dependency management in the iptables layer.
         self.rules_ref_helper.replace_all(new_profile_ids)
 
         if endpoint != self.endpoint:
             self._dirty = True
+
+        # When an IP address is removed, squash any old conntrack entries for
+        # that IP address.  This prevents the table from becoming full under
+        # high VM churn and it also prevents a new endpoint that happens to
+        # get a reused IP from spoofing old streams.
+        old_endpoint = self.endpoint or {}
+        old_ip_nets = set(old_endpoint.get(self.nets_key, []))
+        removed_nets = old_ip_nets - new_ip_nets
+        remove_conntrack_flows([futils.net_to_ip(n) for n in removed_nets])
 
         # Store off the endpoint we were passed.
         self.endpoint = endpoint
@@ -374,16 +390,14 @@ class LocalEndpoint(RefCountedActor):
         try:
             if self.ip_type == IPV4:
                 devices.configure_interface_ipv4(self._iface_name)
-                nets_key = "ipv4_nets"
                 reset_arp = mac_changed
             else:
                 ipv6_gw = self.endpoint.get("ipv6_gateway", None)
                 devices.configure_interface_ipv6(self._iface_name, ipv6_gw)
-                nets_key = "ipv6_nets"
                 reset_arp = False
 
             ips = set()
-            for ip in self.endpoint.get(nets_key, []):
+            for ip in self.endpoint.get(self.nets_key, []):
                 ips.add(futils.net_to_ip(ip))
             devices.set_routes(self.ip_type, ips,
                                self._iface_name,

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -263,7 +263,6 @@ class LocalEndpoint(RefCountedActor):
         old_endpoint = self.endpoint or {}
         old_ip_nets = set(old_endpoint.get(self.nets_key, []))
         removed_nets = old_ip_nets - new_ip_nets
-        remove_conntrack_flows([futils.net_to_ip(n) for n in removed_nets])
 
         # Store off the endpoint we were passed.
         self.endpoint = endpoint

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -256,14 +256,6 @@ class LocalEndpoint(RefCountedActor):
         if endpoint != self.endpoint:
             self._dirty = True
 
-        # When an IP address is removed, squash any old conntrack entries for
-        # that IP address.  This prevents the table from becoming full under
-        # high VM churn and it also prevents a new endpoint that happens to
-        # get a reused IP from spoofing old streams.
-        old_endpoint = self.endpoint or {}
-        old_ip_nets = set(old_endpoint.get(self.nets_key, []))
-        removed_nets = old_ip_nets - new_ip_nets
-
         # Store off the endpoint we were passed.
         self.endpoint = endpoint
 

--- a/debian/control
+++ b/debian/control
@@ -68,6 +68,7 @@ Package: calico-felix
 Architecture: all
 Depends:
  calico-common (= ${binary:Version}),
+ conntrack,
  ipset,
  net-tools,
  python-netaddr,

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -91,7 +91,7 @@ This package provides common files.
 %package felix
 Group:          Applications/Engineering
 Summary:        Project Calico virtual networking for cloud data centers
-Requires:       calico-common, ipset, net-tools, python-devel, python-netaddr, python-gevent
+Requires:       calico-common, conntrack-tools, ipset, net-tools, python-devel, python-netaddr, python-gevent
 
 %description felix
 This package provides the Felix component.


### PR DESCRIPTION
@plwhite this should improve #618 and #617 as well as closing a potential security hole caused by address reuse.

Please can you review, then I'll add UT if you agree it's the right approach?

TODO list:
- [x] Make markups
- [x] add the conntrack tool as a dependency of our debs
- [x] and RPMs
- [x] UT