### PR TITLE
Remove use of 'here' from links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ with higher
 ## How do I get started with Project Calico?
 
 To get started on [OpenStack](http://www.openstack.org/) follow the
-instructions [here](http://docs.projectcalico.org/en/latest/openstack.html). To
-get started on [Docker](http://www.docker.com/) follow the instructions
-[here](https://github.com/Metaswitch/calico-docker/blob/master/README.md).
+instructions [in our docs](http://docs.projectcalico.org/en/latest/openstack.html).
+To get started on [Docker](http://www.docker.com/) follow the instructions
+[in the calico-docker repo](https://github.com/Metaswitch/calico-docker/blob/master/README.md).
 
-Technical documentation is [here](http://docs.projectcalico.org/). For
+Technical documentation is at <http://docs.projectcalico.org/>. For
 information about contributing to Calico itself, see the section titled
 'Contributing' below.
 


### PR DESCRIPTION
Rather than using 'click here' or similar, it's better to provide
a short description of where the link goes or what it is.