### PR TITLE
BIRD config: remove 'device routes' to stop NETLINK: File Exists log spam

### DIFF
--- a/etc/bird/calico-bird.conf.template
+++ b/etc/bird/calico-bird.conf.template
@@ -26,7 +26,6 @@ protocol kernel {
   learn;          # Learn all alien routes from the kernel
   persist;        # Don't remove routes on bird shutdown
   scan time 2;    # Scan kernel routing table every 2 seconds
-  device routes;
   import all;
   export all;     # Default is export none
 }

--- a/etc/bird/calico-bird6.conf.template
+++ b/etc/bird/calico-bird6.conf.template
@@ -26,7 +26,6 @@ protocol kernel {
   learn;          # Learn all alien routes from the kernel
   persist;        # Don't remove routes on bird shutdown
   scan time 2;    # Scan kernel routing table every 2 seconds
-  device routes;
   import all;
   export all;     # Default is export none
 }


### PR DESCRIPTION
Issue #388 fix.  Also requires a calico-chef update (and possibly updates to Juju and calico-docker too).

BIRD tries to reinstall the route to the subnet the host is on (e.g. 172.18.203.0/24 for most of our test kit).  This fails, because it already exists, leading to a 'NETLINK: File Exists' log every 2 seconds.

The 'device routes' option in the BIRD config stops BIRD from ignoring these routes.  Honestly, I'm not exactly sure why BIRD still accepts the endpoint routes without 'device routes', but I've tried it and it seems to work, without the log spam.