### PR TITLE
Remove a couple of spammy logs.

### DIFF
--- a/calico/felix/fetcd.py
+++ b/calico/felix/fetcd.py
@@ -291,9 +291,12 @@ class EtcdWatcher(Actor):
                 self._reconnect()
             except (ConnectTimeoutError,
                     urllib3.exceptions.HTTPError,
-                    httplib.HTTPException):
+                    httplib.HTTPException) as e:
+                # We don't log out the stack trace here because it can spam the
+                # logs heavily if the requests keep failing.  The errors are
+                # very descriptive anyway.
                 _log.warning("Low-level HTTP error, reconnecting to "
-                             "etcd.", exc_info=True)
+                             "etcd: %r.", e)
                 self._reconnect()
             except (EtcdClusterIdChanged, EtcdEventIndexCleared) as e:
                 _log.warning("Out of sync with etcd (%r).  Reconnecting "

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -317,8 +317,6 @@ class IpsetManager(ReferenceManager):
             for ip in old_ips:
                 self._remove_mapping(tag, profile_id, endpoint_id, ip)
 
-        _log.info("Endpoint update complete")
-
     def _add_mapping(self, tag_id, profile_id, endpoint_id, ip_address):
         """
         Adds the given tag->IP->profile->endpoint mapping to the index.


### PR DESCRIPTION
The HTTP-related logs get very spammy when etcd is being migrated or rebuilt and those errors are pretty descriptive anyway so the stack is less useful.

The info-level log for endpoint updates is spammy when we're at high scale across the whole cluster.