### PR TITLE
Handle 0 in a TCP port range by using standard port match.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   objects.
 - Allow different hosts to have different interface prefixes for combined
   OpenStack and Docker systems.
+- Add missing support for 0 as a TCP port.
 
 ## 0.23
 

--- a/calico/common.py
+++ b/calico/common.py
@@ -494,7 +494,7 @@ def validate_rule_port(port):
     :returns: None or an error string if invalid
     """
     if isinstance(port, int):
-        if port < 1 or port > 65535:
+        if port < 0 or port > 65535:
             return "integer out of range"
         return None
 
@@ -513,7 +513,7 @@ def validate_rule_port(port):
     except ValueError:
         return "range invalid"
 
-    if start >= end or start < 1 or end > 65535:
+    if start >= end or start < 0 or end > 65535:
         return "range invalid"
 
     return None

--- a/calico/test/test_common.py
+++ b/calico/test/test_common.py
@@ -621,8 +621,8 @@ class TestCommon(unittest.TestCase):
     def test_validate_rule_port(self):
         self.assertEqual(common.validate_rule_port(73), None)
         self.assertEqual(common.validate_rule_port("57:123"), None)
-        self.assertEqual(common.validate_rule_port(0),
-                         "integer out of range")
+        self.assertEqual(common.validate_rule_port("0:1024"), None)
+        self.assertEqual(common.validate_rule_port(0), None)
         self.assertEqual(common.validate_rule_port(65536),
                          "integer out of range")
         self.assertEqual(common.validate_rule_port([]),
@@ -637,7 +637,7 @@ class TestCommon(unittest.TestCase):
                          "range invalid")
         self.assertEqual(common.validate_rule_port("3:1"),
                          "range invalid")
-        self.assertEqual(common.validate_rule_port("0:3"),
+        self.assertEqual(common.validate_rule_port("-1:3"),
                          "range invalid")
         self.assertEqual(common.validate_rule_port("5:65536"),
                          "range invalid")


### PR DESCRIPTION
Extract 0 out when splitting ports into chunks.

Fixes #631.  0 is a reserved but, I suppose, valid port number.