### PR TITLE
Separate FORWARD and INPUT chains in Felix

### DIFF
--- a/calico/felix/dispatch.py
+++ b/calico/felix/dispatch.py
@@ -165,16 +165,16 @@ class DispatchChains(Actor):
         # Special case: allow the metadata IP through from all interfaces.
         if self.config.METADATA_IP is not None and self.ip_version == 4:
             # Need to allow outgoing Metadata requests.
-            root_from_upds.append("--append %s "
-                                  "--protocol tcp "
-                                  "--in-interface %s+ "
-                                  "--destination %s "
-                                  "--dport %s "
-                                  "--jump RETURN" %
-                                  (CHAIN_FROM_ENDPOINT,
-                                   self.config.IFACE_PREFIX,
-                                   self.config.METADATA_IP,
-                                   self.config.METADATA_PORT))
+            root_inbound_upds.append("--append %s "
+                                     "--protocol tcp "
+                                     "--in-interface %s+ "
+                                     "--destination %s "
+                                     "--dport %s "
+                                     "--jump RETURN" %
+                                     (CHAIN_INBOUND,
+                                      self.config.IFACE_PREFIX,
+                                      self.config.METADATA_IP,
+                                      self.config.METADATA_PORT))
 
         # Special case: allow DHCP inbound from all interfaces.
         if self.ip_version == 4:

--- a/calico/felix/dispatch.py
+++ b/calico/felix/dispatch.py
@@ -24,7 +24,7 @@ import logging
 from calico.felix.actor import Actor, actor_message, wait_and_check
 from calico.felix.frules import (
     CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT, CHAIN_FROM_LEAF, CHAIN_TO_LEAF,
-    chain_names, interface_to_suffix
+    CHAIN_INBOUND, chain_names, interface_to_suffix
 )
 
 _log = logging.getLogger(__name__)
@@ -156,6 +156,7 @@ class DispatchChains(Actor):
         updates = defaultdict(list)
         root_to_upds = updates[CHAIN_TO_ENDPOINT]
         root_from_upds = updates[CHAIN_FROM_ENDPOINT]
+        root_inbound_upds = updates[CHAIN_INBOUND]
 
         dependencies = defaultdict(set)
         root_to_deps = dependencies[CHAIN_TO_ENDPOINT]
@@ -174,6 +175,26 @@ class DispatchChains(Actor):
                                    self.config.IFACE_PREFIX,
                                    self.config.METADATA_IP,
                                    self.config.METADATA_PORT))
+
+        # Special case: allow DHCP inbound from all interfaces.
+        if self.ip_version == 4:
+            dhcp_src_port = 68
+            dhcp_dst_port = 67
+        else:
+            assert self.ip_version == 6
+            dhcp_src_port = 546
+            dhcp_dst_port = 547
+
+        root_inbound_upds.append("--append %s "
+                                 "--protocol udp "
+                                 "--in-interface %s+ "
+                                 "--sport %s "
+                                 "--dport %s "
+                                 "--jump RETURN" %
+                                 (CHAIN_INBOUND,
+                                  self.config.IFACE_PREFIX,
+                                  dhcp_src_port,
+                                  dhcp_dst_port))
 
         # Separate the interface names by their prefixes so we can count them
         # and decide whether to program a leaf chain or not.
@@ -247,6 +268,7 @@ class DispatchChains(Actor):
         # we don't know about yet can't bypass our rules.
         root_from_upds.append("--append %s --jump DROP" % CHAIN_FROM_ENDPOINT)
         root_to_upds.append("--append %s --jump DROP" % CHAIN_TO_ENDPOINT)
+        root_inbound_upds.append("--append %s --jump DROP" % CHAIN_INBOUND)
         chains_to_delete = self.programmed_leaf_chains - new_leaf_chains
 
         return chains_to_delete, dependencies, updates, new_leaf_chains

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -493,14 +493,6 @@ def _get_endpoint_rules(endpoint_id, suffix, ip_version, local_ips, mac,
                       "--ctstate RELATED,ESTABLISHED --jump RETURN" %
                       from_chain_name)
 
-    if ip_version == 4:
-        from_chain.append("--append %s --protocol udp --sport 68 --dport 67 "
-                          "--jump RETURN" % from_chain_name)
-    else:
-        assert ip_version == 6
-        from_chain.append("--append %s --protocol udp --sport 546 --dport 547 "
-                          "--jump RETURN" % from_chain_name)
-
     # Combined anti-spoofing and jump to profile rules.  The only way to
     # get to a profile chain is to have the correct IP and MAC address.
     from_deps = set()

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -39,6 +39,7 @@ CHAIN_INPUT = FELIX_PREFIX + "INPUT"
 CHAIN_FORWARD = FELIX_PREFIX + "FORWARD"
 CHAIN_TO_ENDPOINT = FELIX_PREFIX + "TO-ENDPOINT"
 CHAIN_FROM_ENDPOINT = FELIX_PREFIX + "FROM-ENDPOINT"
+CHAIN_INBOUND = FELIX_PREFIX + "INBOUND"
 CHAIN_TO_LEAF = FELIX_PREFIX + "TO-EP-PFX"
 CHAIN_FROM_LEAF = FELIX_PREFIX + "FROM-EP-PFX"
 CHAIN_TO_PREFIX = FELIX_PREFIX + "to-"
@@ -118,7 +119,7 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
                                         (v6_filter_updater, None)]:
         input_chain = [
             "--append %s --jump %s --in-interface %s" %
-            (CHAIN_INPUT, CHAIN_FROM_ENDPOINT, iface_match),
+            (CHAIN_INPUT, CHAIN_INBOUND, iface_match),
             "--append %s --jump ACCEPT --in-interface %s" %
             (CHAIN_INPUT, iface_match),
         ]
@@ -148,7 +149,7 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
             },
             {
                 CHAIN_FORWARD: set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT]),
-                CHAIN_INPUT: set([CHAIN_FROM_ENDPOINT]),
+                CHAIN_INPUT: set([CHAIN_INBOUND]),
             },
             async=False)
         iptables_updater.ensure_rule_inserted(

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -378,6 +378,10 @@ def _build_input_chain(iface_match, metadata_addr, metadata_port,
     Returns a list of rules that should be applied to the INPUT chain.
     """
     chain = []
+    chain.append("--append %s --match conntrack --ctstate INVALID "
+                 "--jump DROP" % CHAIN_INPUT)
+    chain.append("--append %s --match conntrack --ctstate RELATED,ESTABLISHED "
+                 "--jump ACCEPT" % CHAIN_INPUT)
 
     if metadata_addr is not None:
         chain.append(
@@ -395,7 +399,7 @@ def _build_input_chain(iface_match, metadata_addr, metadata_port,
     chain.append(
         "--append %s --in-interface %s --jump DROP" %
         (CHAIN_INPUT, iface_match)
-     )
+    )
 
     return chain
 

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -160,8 +160,8 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
             {
                 CHAIN_FORWARD: set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT]),
                 CHAIN_INPUT: set(),
-            }
-        )
+            },
+            async=False)
 
         iptables_updater.ensure_rule_inserted(
             "INPUT --jump %s" % CHAIN_INPUT,

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -39,7 +39,6 @@ CHAIN_INPUT = FELIX_PREFIX + "INPUT"
 CHAIN_FORWARD = FELIX_PREFIX + "FORWARD"
 CHAIN_TO_ENDPOINT = FELIX_PREFIX + "TO-ENDPOINT"
 CHAIN_FROM_ENDPOINT = FELIX_PREFIX + "FROM-ENDPOINT"
-CHAIN_INBOUND = FELIX_PREFIX + "INBOUND"
 CHAIN_TO_LEAF = FELIX_PREFIX + "TO-EP-PFX"
 CHAIN_FROM_LEAF = FELIX_PREFIX + "FROM-EP-PFX"
 CHAIN_TO_PREFIX = FELIX_PREFIX + "to-"
@@ -117,12 +116,23 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
     for iptables_updater, hosts_set in [(v4_filter_updater, HOSTS_IPSET_V4),
                                         # FIXME support IP-in-IP for IPv6.
                                         (v6_filter_updater, None)]:
-        input_chain = [
-            "--append %s --jump %s --in-interface %s" %
-            (CHAIN_INPUT, CHAIN_INBOUND, iface_match),
-            "--append %s --jump ACCEPT --in-interface %s" %
-            (CHAIN_INPUT, iface_match),
-        ]
+        if iptables_updater is v4_filter_updater:
+            input_chain = _build_input_chain(
+                iface_match=iface_match,
+                metadata_addr=config.METADATA_IP,
+                metadata_port=config.METADATA_PORT,
+                dhcp_src_port=68,
+                dhcp_dst_port=67
+            )
+        else:
+            input_chain = _build_input_chain(
+                iface_match=iface_match,
+                metadata_addr=None,
+                metadata_port=None,
+                dhcp_src_port=546,
+                dhcp_dst_port=547
+            )
+
         forward_chain = [
             "--append %s --jump %s --in-interface %s" %
             (CHAIN_FORWARD, CHAIN_FROM_ENDPOINT, iface_match),
@@ -149,9 +159,10 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
             },
             {
                 CHAIN_FORWARD: set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT]),
-                CHAIN_INPUT: set([CHAIN_INBOUND]),
-            },
-            async=False)
+                CHAIN_INPUT: set(),
+            }
+        )
+
         iptables_updater.ensure_rule_inserted(
             "INPUT --jump %s" % CHAIN_INPUT,
             async=False)
@@ -359,6 +370,34 @@ def _rule_to_iptables_fragment(chain_name, rule, ip_version, tag_to_ipset,
                               else on_deny)
 
     return " ".join(str(x) for x in update_fragments)
+
+
+def _build_input_chain(iface_match, metadata_addr, metadata_port,
+                       dhcp_src_port, dhcp_dst_port):
+    """
+    Returns a list of rules that should be applied to the INPUT chain.
+    """
+    chain = []
+
+    if metadata_addr is not None:
+        chain.append(
+            "--append %s --protocol tcp --in-interface %s "
+            "--destination %s --dport %s --jump ACCEPT" %
+            (CHAIN_INPUT, iface_match, metadata_addr, metadata_port)
+        )
+
+    chain.append(
+        "--append %s --protocol udp --in-interface %s --sport %d "
+        "--dport %s --jump ACCEPT" %
+        (CHAIN_INPUT, iface_match, dhcp_src_port, dhcp_dst_port)
+    )
+
+    chain.append(
+        "--append %s --in-interface %s --jump DROP" %
+        (CHAIN_INPUT, iface_match)
+     )
+
+    return chain
 
 
 def interface_to_suffix(config, iface_name):

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -147,6 +147,10 @@ class TestDispatchChains(BaseTestCase):
                 '--append felix-FROM-ENDPOINT --in-interface tapb+ --goto felix-FROM-EP-PFX-b',
                 '--append felix-FROM-ENDPOINT --in-interface tapc --goto felix-from-c',
                 '--append felix-FROM-ENDPOINT --jump DROP'],
+            'felix-INBOUND': [
+                '--append felix-INBOUND --protocol udp --in-interface tap+ --sport 68 --dport 67 --jump RETURN',
+                '--append felix-INBOUND --jump DROP',
+            ],
             'felix-FROM-EP-PFX-a': [
                 # Per-prefix chain has one entry per endpoint.
                 '--append felix-FROM-EP-PFX-a --in-interface tapa1 --goto felix-from-a1',

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -25,7 +25,7 @@ import mock
 
 from calico.felix.test.base import BaseTestCase
 from calico.felix.dispatch import (
-    DispatchChains, CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT
+    DispatchChains, CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT, CHAIN_INBOUND,
 )
 
 
@@ -53,6 +53,7 @@ class TestDispatchChains(BaseTestCase):
                                args,
                                to_updates,
                                from_updates,
+                               inbound_updates,
                                to_chain_names,
                                from_chain_names):
         # We only care about positional arguments
@@ -66,6 +67,7 @@ class TestDispatchChains(BaseTestCase):
         # is the DROP rule.
         self.assertItemsEqual(args[0][CHAIN_TO_ENDPOINT], to_updates)
         self.assertItemsEqual(args[0][CHAIN_FROM_ENDPOINT], from_updates)
+        self.assertItemsEqual(args[0][CHAIN_INBOUND], inbound_updates)
         self.assertEqual(args[0][CHAIN_TO_ENDPOINT][-1], to_updates[-1])
         self.assertEqual(args[0][CHAIN_FROM_ENDPOINT][-1], from_updates[-1])
 
@@ -98,13 +100,19 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
+        inbound_updates = [
+            '--append felix-INBOUND --protocol udp --in-interface tap+ '
+            '--sport 68 --dport 67 --jump RETURN',
+            '--append felix-INBOUND --jump DROP',
+        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
         self.iptables_updater.assertCalledOnce()
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, to_chain_names, from_chain_names
+            args, to_updates, from_updates, inbound_updates, to_chain_names,
+            from_chain_names
         )
 
     def test_tree_building(self):
@@ -195,13 +203,23 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
+        inbound_updates = [
+            '--append felix-INBOUND --protocol udp --in-interface tap+ '
+            '--sport 68 --dport 67 --jump RETURN',
+            '--append felix-INBOUND --jump DROP',
+        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
         self.iptables_updater.assertCalledOnce()
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, to_chain_names, from_chain_names
+            args,
+            to_updates,
+            from_updates,
+            inbound_updates,
+            to_chain_names,
+            from_chain_names
         )
 
     def test_applying_snapshot_dirty(self):
@@ -231,13 +249,23 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
+        inbound_updates = [
+            '--append felix-INBOUND --protocol udp --in-interface tap+ '
+            '--sport 68 --dport 67 --jump RETURN',
+            '--append felix-INBOUND --jump DROP',
+        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
         self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, to_chain_names, from_chain_names
+            args,
+            to_updates,
+            from_updates,
+            inbound_updates,
+            to_chain_names,
+            from_chain_names
         )
 
     def test_applying_empty_snapshot(self):
@@ -261,13 +289,23 @@ class TestDispatchChains(BaseTestCase):
         to_updates = [
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
+        inbound_updates = [
+            '--append felix-INBOUND --protocol udp --in-interface tap+ '
+            '--sport 68 --dport 67 --jump RETURN',
+            '--append felix-INBOUND --jump DROP',
+        ]
         from_chain_names = set()
         to_chain_names = set()
 
         self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, to_chain_names, from_chain_names
+            args,
+            to_updates,
+            from_updates,
+            inbound_updates,
+            to_chain_names,
+            from_chain_names
         )
 
     def test_on_endpoint_added_simple(self):
@@ -296,13 +334,23 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
+        inbound_updates = [
+            '--append felix-INBOUND --protocol udp --in-interface tap+ '
+            '--sport 68 --dport 67 --jump RETURN',
+            '--append felix-INBOUND --jump DROP',
+        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
         self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, to_chain_names, from_chain_names
+            args,
+            to_updates,
+            from_updates,
+            inbound_updates,
+            to_chain_names,
+            from_chain_names
         )
 
     def test_on_endpoint_added_idempotent(self):
@@ -346,6 +394,11 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
+        inbound_updates = [
+            '--append felix-INBOUND --protocol udp --in-interface tap+ '
+            '--sport 68 --dport 67 --jump RETURN',
+            '--append felix-INBOUND --jump DROP',
+        ]
         from_chain_names = set(['felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-123456', 'felix-to-b7d849'])
 
@@ -353,7 +406,12 @@ class TestDispatchChains(BaseTestCase):
         self.assertEqual(self.iptables_updater.rewrite_chains.call_count, 2)
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, to_chain_names, from_chain_names
+            args,
+            to_updates,
+            from_updates,
+            inbound_updates,
+            to_chain_names,
+            from_chain_names
         )
 
     def test_on_endpoint_removed_idempotent(self):

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -87,8 +87,6 @@ class TestDispatchChains(BaseTestCase):
         self.step_actor(d)
 
         from_updates = [
-            '--append felix-FROM-ENDPOINT --protocol tcp --in-interface tap+ '
-            '--destination 127.0.0.1 --dport 8775 --jump RETURN',
             '--append felix-FROM-ENDPOINT --in-interface tapabcdef --goto felix-from-abcdef',
             '--append felix-FROM-ENDPOINT --in-interface tap123456 --goto felix-from-123456',
             '--append felix-FROM-ENDPOINT --in-interface tapb7d849 --goto felix-from-b7d849',
@@ -101,6 +99,8 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
         inbound_updates = [
+            '--append felix-INBOUND --protocol tcp --in-interface tap+ '
+            '--destination 127.0.0.1 --dport 8775 --jump RETURN',
             '--append felix-INBOUND --protocol udp --in-interface tap+ '
             '--sport 68 --dport 67 --jump RETURN',
             '--append felix-INBOUND --jump DROP',

--- a/calico/felix/test/test_dispatch.py
+++ b/calico/felix/test/test_dispatch.py
@@ -25,7 +25,7 @@ import mock
 
 from calico.felix.test.base import BaseTestCase
 from calico.felix.dispatch import (
-    DispatchChains, CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT, CHAIN_INBOUND,
+    DispatchChains, CHAIN_TO_ENDPOINT, CHAIN_FROM_ENDPOINT
 )
 
 
@@ -53,7 +53,6 @@ class TestDispatchChains(BaseTestCase):
                                args,
                                to_updates,
                                from_updates,
-                               inbound_updates,
                                to_chain_names,
                                from_chain_names):
         # We only care about positional arguments
@@ -67,7 +66,6 @@ class TestDispatchChains(BaseTestCase):
         # is the DROP rule.
         self.assertItemsEqual(args[0][CHAIN_TO_ENDPOINT], to_updates)
         self.assertItemsEqual(args[0][CHAIN_FROM_ENDPOINT], from_updates)
-        self.assertItemsEqual(args[0][CHAIN_INBOUND], inbound_updates)
         self.assertEqual(args[0][CHAIN_TO_ENDPOINT][-1], to_updates[-1])
         self.assertEqual(args[0][CHAIN_FROM_ENDPOINT][-1], from_updates[-1])
 
@@ -98,20 +96,13 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
-        inbound_updates = [
-            '--append felix-INBOUND --protocol tcp --in-interface tap+ '
-            '--destination 127.0.0.1 --dport 8775 --jump RETURN',
-            '--append felix-INBOUND --protocol udp --in-interface tap+ '
-            '--sport 68 --dport 67 --jump RETURN',
-            '--append felix-INBOUND --jump DROP',
-        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
         self.iptables_updater.assertCalledOnce()
         args = self.iptables_updater.rewrite_chains.call_args
         self.assert_iptables_update(
-            args, to_updates, from_updates, inbound_updates, to_chain_names,
+            args, to_updates, from_updates, to_chain_names,
             from_chain_names
         )
 
@@ -155,10 +146,6 @@ class TestDispatchChains(BaseTestCase):
                 '--append felix-FROM-ENDPOINT --in-interface tapb+ --goto felix-FROM-EP-PFX-b',
                 '--append felix-FROM-ENDPOINT --in-interface tapc --goto felix-from-c',
                 '--append felix-FROM-ENDPOINT --jump DROP'],
-            'felix-INBOUND': [
-                '--append felix-INBOUND --protocol udp --in-interface tap+ --sport 68 --dport 67 --jump RETURN',
-                '--append felix-INBOUND --jump DROP',
-            ],
             'felix-FROM-EP-PFX-a': [
                 # Per-prefix chain has one entry per endpoint.
                 '--append felix-FROM-EP-PFX-a --in-interface tapa1 --goto felix-from-a1',
@@ -203,11 +190,6 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
-        inbound_updates = [
-            '--append felix-INBOUND --protocol udp --in-interface tap+ '
-            '--sport 68 --dport 67 --jump RETURN',
-            '--append felix-INBOUND --jump DROP',
-        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
@@ -217,7 +199,6 @@ class TestDispatchChains(BaseTestCase):
             args,
             to_updates,
             from_updates,
-            inbound_updates,
             to_chain_names,
             from_chain_names
         )
@@ -249,11 +230,6 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
-        inbound_updates = [
-            '--append felix-INBOUND --protocol udp --in-interface tap+ '
-            '--sport 68 --dport 67 --jump RETURN',
-            '--append felix-INBOUND --jump DROP',
-        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
@@ -263,7 +239,6 @@ class TestDispatchChains(BaseTestCase):
             args,
             to_updates,
             from_updates,
-            inbound_updates,
             to_chain_names,
             from_chain_names
         )
@@ -289,11 +264,6 @@ class TestDispatchChains(BaseTestCase):
         to_updates = [
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
-        inbound_updates = [
-            '--append felix-INBOUND --protocol udp --in-interface tap+ '
-            '--sport 68 --dport 67 --jump RETURN',
-            '--append felix-INBOUND --jump DROP',
-        ]
         from_chain_names = set()
         to_chain_names = set()
 
@@ -303,7 +273,6 @@ class TestDispatchChains(BaseTestCase):
             args,
             to_updates,
             from_updates,
-            inbound_updates,
             to_chain_names,
             from_chain_names
         )
@@ -334,11 +303,6 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
-        inbound_updates = [
-            '--append felix-INBOUND --protocol udp --in-interface tap+ '
-            '--sport 68 --dport 67 --jump RETURN',
-            '--append felix-INBOUND --jump DROP',
-        ]
         from_chain_names = set(['felix-from-abcdef', 'felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-abcdef', 'felix-to-123456', 'felix-to-b7d849'])
 
@@ -348,7 +312,6 @@ class TestDispatchChains(BaseTestCase):
             args,
             to_updates,
             from_updates,
-            inbound_updates,
             to_chain_names,
             from_chain_names
         )
@@ -394,11 +357,6 @@ class TestDispatchChains(BaseTestCase):
             '--append felix-TO-ENDPOINT --out-interface tapb7d849 --goto felix-to-b7d849',
             '--append felix-TO-ENDPOINT --jump DROP',
         ]
-        inbound_updates = [
-            '--append felix-INBOUND --protocol udp --in-interface tap+ '
-            '--sport 68 --dport 67 --jump RETURN',
-            '--append felix-INBOUND --jump DROP',
-        ]
         from_chain_names = set(['felix-from-123456', 'felix-from-b7d849'])
         to_chain_names = set(['felix-to-123456', 'felix-to-b7d849'])
 
@@ -409,7 +367,6 @@ class TestDispatchChains(BaseTestCase):
             args,
             to_updates,
             from_updates,
-            inbound_updates,
             to_chain_names,
             from_chain_names
         )


### PR DESCRIPTION
This resolves #196.

The effect of this patch is to stop adding felix-FROM-ENDPOINT to the INPUT chain of the filter table in iptables, and instead to add another top-level chain that contains only rules that affect inbound packets. This creates a split between the endpoint security rules (which apply only to forwarded packets) and the rules that affect traffic intended to reach the host.

Right now this is set up to be extremely secure, but we may want to relax it slightly. ICMP packets from guests leap to mind as a possible exemption we'll want to grant.

I have to drop a few extra commits that will move some other rules from where they are to this new INPUT chain. In particular, the metadata rule needs to move in.

I haven't had a chance to live test this yet, and the UT coverage here isn't great, so I suggest not merging it until someone gets a chance to live-test it. Nevertheless, review would be welcome, particularly from @plwhite and @fasaxc.