### PR TITLE
Allow different hosts to have different interface prefixes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Reduce felix occupancy by replacing endpoint dictionaries by "struct"
   objects.
+- Allow different hosts to have different interface prefixes for combined
+  OpenStack and Docker systems.
 
 ## 0.23
 


### PR DESCRIPTION
This is allowed for mixed OpenStack / Docker interop.