### PR TITLE
Add support for matching on arbitrary IP protocols.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Allow different hosts to have different interface prefixes for combined
   OpenStack and Docker systems.
 - Add missing support for 0 as a TCP port.
+- Add support for arbitrary IP protocols.
 
 ## 0.23
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   objects.
 - Allow different hosts to have different interface prefixes for combined
   OpenStack and Docker systems.
+- Add missing support for 0 as a TCP port.
 
 ## 0.23
 

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -19,7 +19,6 @@ felix.frules
 Felix rule management, including iptables and ipsets.
 """
 import logging
-from subprocess import CalledProcessError
 import itertools
 from calico.felix import futils
 from calico.common import KNOWN_RULE_KEYS
@@ -304,11 +303,10 @@ def _rule_to_iptables_fragment(chain_name, rule, ip_version, tag_to_ipset,
     update_fragments = ["--append", chain_name]
     append = lambda *args: update_fragments.extend(args)
 
-    proto = None
-    if "protocol" in rule:
+    proto = rule.get("protocol")
+    if proto:
         proto = rule["protocol"]
-        assert proto in ["tcp", "udp", "icmp", "icmpv6"]
-        append("--protocol", proto)
+        append("--protocol", str(proto))
 
     for dirn in ["src", "dst"]:
         # Some params use the long-form of the name.
@@ -412,3 +410,4 @@ def chain_names(endpoint_suffix):
 
 class UnsupportedICMPType(Exception):
     pass
+

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -170,3 +170,8 @@ class TestRules(BaseTestCase):
     def test_bad_icmp_type(self):
         with self.assertRaises(UnsupportedICMPType):
             _rule_to_iptables_fragment("foo", {"icmp_type": 255}, 4, {})
+
+    def test_bad_protocol_with_ports(self):
+        with self.assertRaises(AssertionError):
+            _rule_to_iptables_fragment("foo", {"protocol": "10",
+                                               "src_ports": [1]}, 4, {})

--- a/calico/test/test_common.py
+++ b/calico/test/test_common.py
@@ -482,7 +482,8 @@ class TestCommon(unittest.TestCase):
         rules = {'inbound_rules': [rule],
                  'outbound_rules': []}
         with self.assertRaisesRegexp(ValidationFailed,
-                                     "Invalid protocol in rule"):
+                                     "Invalid protocol bloop in rule "
+                                     "{'protocol': 'bloop'}"):
             common.validate_rules(profile_id, rules)
 
         rule = {'ip_version': 5}
@@ -513,6 +514,26 @@ class TestCommon(unittest.TestCase):
         rules = {'inbound_rules': [rule],
                  'outbound_rules': []}
         common.validate_rules(profile_id, rules)
+
+        rule = {'src_tag': "abc",
+                'protocol': "123"}
+        rules = {'inbound_rules': [rule],
+                 'outbound_rules': []}
+        common.validate_rules(profile_id, rules)
+
+        rule = {'protocol': "256"}
+        rules = {'inbound_rules': [rule],
+                 'outbound_rules': []}
+        with self.assertRaisesRegexp(ValidationFailed,
+                                     "Invalid protocol 256 in rule"):
+            common.validate_rules(profile_id, rules)
+
+        rule = {'protocol': "0"}
+        rules = {'inbound_rules': [rule],
+                 'outbound_rules': []}
+        with self.assertRaisesRegexp(ValidationFailed,
+                                     "Invalid protocol 0 in rule"):
+            common.validate_rules(profile_id, rules)
 
         rule = {'src_tag': "a!b",
                 'protocol': "icmp"}


### PR DESCRIPTION
@plwhite This PR is against smc-fix-rules, which is open in a separate PR.  Once that one is merged, this one should be changed to be based on master.

Fixes #608.