### PR TITLE
Add support for IP-in-IP interfaces.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.24-dev
 
+- Add support for routing over IP-in-IP interfaces in order to make it 
+  easier to evaluate Calico without reconfiguring underlying network.
 - Reduce felix occupancy by replacing endpoint dictionaries by "struct"
   objects.
 - Allow different hosts to have different interface prefixes for combined

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -68,6 +68,8 @@ ENDPOINT_KEY_RE = re.compile(
     r'(?P<workload_id>[^/]+)/'
     r'endpoint/(?P<endpoint_id>[^/]+)')
 
+HOST_IP_KEY_RE = re.compile(r'^' + HOST_DIR +
+                            r'/(?P<hostname>[^/]+)/bird_ip')
 
 def dir_for_host(hostname):
     return HOST_DIR+ "/%s" % hostname

--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -121,7 +121,15 @@ class ConfigParameter(object):
                     raise ConfigException("Field was not integer",
                                           self)
             elif self.value_is_bool:
-                self.value = (str(value).lower() in ("true", "1", "yes", "y"))
+                lower_val = str(value).lower()
+                log.debug("Parsing %r as a Boolean.", lower_val)
+                if lower_val in ("true", "1", "yes", "y", "t"):
+                    self.value = True
+                elif lower_val in ("false", "0", "no", "n", "f"):
+                    self.value = False
+                else:
+                    raise ConfigException("Field was not a valid Boolean",
+                                          self)
             else:
                 # Calling str in principle can throw an exception, but it's
                 # hard to see how in practice, so don't catch and wrap.
@@ -174,7 +182,7 @@ class Config(object):
         self.add_parameter("LogSeverityScreen",
                            "Log severity for logging to screen", "ERROR")
         self.add_parameter("IpInIpEnabled",
-                           "IP-in-IP tunnel support enabled", False,
+                           "IP-in-IP device support enabled", False,
                            value_is_bool=True)
 
         # Read the environment variables, then the configuration file.
@@ -221,9 +229,6 @@ class Config(object):
         self.LOGLEVSYS = self.parameters["LogSeveritySys"].value
         self.LOGLEVSCR = self.parameters["LogSeverityScreen"].value
         self.IP_IN_IP_ENABLED = self.parameters["IpInIpEnabled"].value
-        # Hard-coded.  For now, we require the global tunnel device, which is
-        # auto-created by the kernel.
-        self.IP_IN_IP_TUNNEL_NAME = "tunl0"
 
         self._validate_cfg(final=final)
 

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -19,11 +19,12 @@ felix.frules
 Felix rule management, including iptables and ipsets.
 """
 import logging
-from subprocess import CalledProcessError
 import itertools
+from calico.felix import devices
 from calico.felix import futils
 from calico.common import KNOWN_RULE_KEYS
 import re
+from calico.felix.ipsets import HOSTS_IPSET_V4
 
 _log = logging.getLogger(__name__)
 
@@ -75,6 +76,18 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
     # then this string is "tap+".
     iface_match = config.IFACE_PREFIX + "+"
 
+    # If enabled, create the IP-in-IP device
+    if config.IP_IN_IP_ENABLED:
+        _log.info("IP-in-IP tunnel enabled ensuring tunnel device exists.")
+        tunnel_name = config.IP_IN_IP_TUNNEL_NAME
+        if not devices.interface_exists(tunnel_name):
+            _log.info("Tunnel device didn't exist; creating.")
+            futils.check_call(["ip", "tunnel", "add", tunnel_name,
+                               "mode", "ipip"])
+        if not devices.interface_up(tunnel_name):
+            _log.info("Tunnel device wasn't up; enabling.")
+            futils.check_call(["ifconfig", tunnel_name, "up"])
+
     # The IPV4 nat table first. This must have a felix-PREROUTING chain.
     nat_pr = []
     if config.METADATA_IP is not None:
@@ -94,25 +107,38 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
     # Now the filter table. This needs to have calico-filter-FORWARD and
     # calico-filter-INPUT chains, which we must create before adding any
     # rules that send to them.
-    for iptables_updater in [v4_filter_updater, v6_filter_updater]:
+    for iptables_updater, hosts_set in [(v4_filter_updater, HOSTS_IPSET_V4),
+                                        # FIXME support IP-in-IP for IPv6.
+                                        (v6_filter_updater, None)]:
+        # Can't program a rule referencing an ipset before it exists.
+        input_chain = [
+            "--append %s --jump %s --in-interface %s" %
+            (CHAIN_INPUT, CHAIN_FROM_ENDPOINT, iface_match),
+            "--append %s --jump ACCEPT --in-interface %s" %
+            (CHAIN_INPUT, iface_match),
+        ]
+        forward_chain = [
+            "--append %s --jump %s --in-interface %s" %
+            (CHAIN_FORWARD, CHAIN_FROM_ENDPOINT, iface_match),
+            "--append %s --jump %s --out-interface %s" %
+            (CHAIN_FORWARD, CHAIN_TO_ENDPOINT, iface_match),
+            "--append %s --jump ACCEPT --in-interface %s" %
+            (CHAIN_FORWARD, iface_match),
+            "--append %s --jump ACCEPT --out-interface %s" %
+            (CHAIN_FORWARD, iface_match),
+        ]
+        if hosts_set and config.IP_IN_IP_ENABLED:
+            hosts_set.ensure_exists()
+            input_chain[:0] = [
+                # Block IP-in-IP except from white-listed hosts.
+                "--append %s --protocol ipencap "
+                "--match set ! --match-set %s src --jump DROP" %
+                (CHAIN_INPUT, hosts_set.set_name),
+            ]
         iptables_updater.rewrite_chains(
             {
-                CHAIN_FORWARD: [
-                    "--append %s --jump %s --in-interface %s" %
-                        (CHAIN_FORWARD, CHAIN_FROM_ENDPOINT, iface_match),
-                    "--append %s --jump %s --out-interface %s" %
-                        (CHAIN_FORWARD, CHAIN_TO_ENDPOINT, iface_match),
-                    "--append %s --jump ACCEPT --in-interface %s" %
-                        (CHAIN_FORWARD, iface_match),
-                    "--append %s --jump ACCEPT --out-interface %s" %
-                        (CHAIN_FORWARD, iface_match),
-                ],
-                CHAIN_INPUT: [
-                    "--append %s --jump %s --in-interface %s" %
-                        (CHAIN_INPUT, CHAIN_FROM_ENDPOINT, iface_match),
-                    "--append %s --jump ACCEPT --in-interface %s" %
-                        (CHAIN_INPUT, iface_match),
-                ]
+                CHAIN_FORWARD: forward_chain,
+                CHAIN_INPUT: input_chain
             },
             {
                 CHAIN_FORWARD: set([CHAIN_FROM_ENDPOINT, CHAIN_TO_ENDPOINT]),

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -697,6 +697,13 @@ class Ipset(object):
         futils.call_silent(["ipset", "destroy", self.temp_set_name])
 
 
+# For tunnel support, a global ipset that contains the IP addresses of all
+# the calico hosts.
+HOSTS_IPSET_V4 = Ipset(FELIX_PFX + "calico-hosts-4",
+                       FELIX_PFX + "calico-hosts-4-tmp",
+                       "inet")
+
+
 def tag_to_ipset_name(ip_type, tag, tmp=False):
     """
     Turn a (possibly shortened) tag ID into an ipset name.

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -631,6 +631,7 @@ class Ipset(object):
         self.set_name = ipset_name
         self.temp_set_name = temp_ipset_name
         self.type = ipset_type
+        assert ip_family in ("inet", "inet6")
         self.family = ip_family
 
     def ensure_exists(self):

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -635,7 +635,7 @@ class Ipset(object):
 
     def ensure_exists(self):
         """
-        Creates the ipset iif it does not exist.
+        Creates the ipset iff it does not exist.
 
         Leaves the set and its contents untouched if it already exists.
         """
@@ -697,8 +697,9 @@ class Ipset(object):
         futils.call_silent(["ipset", "destroy", self.temp_set_name])
 
 
-# For tunnel support, a global ipset that contains the IP addresses of all
-# the calico hosts.
+# For IP-in-IP support, a global ipset that contains the IP addresses of all
+# the calico hosts.  Only populated when IP-in-IP is enabled and the data is
+# in etcd.
 HOSTS_IPSET_V4 = Ipset(FELIX_PFX + "calico-hosts-4",
                        FELIX_PFX + "calico-hosts-4-tmp",
                        "inet")

--- a/calico/felix/profilerules.py
+++ b/calico/felix/profilerules.py
@@ -218,7 +218,7 @@ class ProfileRules(RefCountedActor):
             new_rules = new_profile.get(rules_key, [])
             tag_to_ip_set_name = {}
             for tag, ipset in self._ipset_refs.iteritems():
-                tag_to_ip_set_name[tag] = ipset.name
+                tag_to_ip_set_name[tag] = ipset.ipset_name
             updates[chain_name] = rules_to_chain_rewrite_lines(
                 chain_name,
                 new_rules,

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -50,16 +50,21 @@ class TestBasic(BaseTestCase):
         else:
             sys.modules['etcd'] = self._real_etcd
 
+    @mock.patch("calico.felix.frules.HOSTS_IPSET_V4")
     @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config")
     @mock.patch("gevent.Greenlet.start", autospec=True)
     @mock.patch("calico.felix.felix.IptablesUpdater", autospec=True)
     @mock.patch("gevent.iwait", autospec=True, side_effect=TestException())
-    def test_main_greenlet(self, m_iwait, m_IptablesUpdater, m_start, m_load):
+    def test_main_greenlet(self, m_iwait, m_IptablesUpdater, m_start, m_load,
+                           m_ipset_4):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_config = mock.Mock(spec=config.Config)
         m_config.HOSTNAME = "myhost"
         m_config.IFACE_PREFIX = "tap"
         m_config.METADATA_IP = None
-        self.assertRaises(TestException,
-                          felix._main_greenlet, m_config)
+        m_config.IP_IN_IP_ENABLED = False
+        m_config.IP_IN_IP_TUNNEL_NAME = "tunl0"
+        with gevent.Timeout(5):
+            self.assertRaises(TestException,
+                              felix._main_greenlet, m_config)
         m_load.assert_called_once_with(async=False)

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -50,21 +50,29 @@ class TestBasic(BaseTestCase):
         else:
             sys.modules['etcd'] = self._real_etcd
 
-    @mock.patch("calico.felix.frules.HOSTS_IPSET_V4")
-    @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config")
+    @mock.patch("calico.felix.devices.interface_up",
+                return_value=False, autospec=True)
+    @mock.patch("calico.felix.devices.interface_exists",
+                return_value=False, autospec=True)
+    @mock.patch("calico.felix.futils.check_call", autospec=True)
+    @mock.patch("calico.felix.frules.HOSTS_IPSET_V4", autospec=True)
+    @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config", autospec=True)
     @mock.patch("gevent.Greenlet.start", autospec=True)
     @mock.patch("calico.felix.felix.IptablesUpdater", autospec=True)
     @mock.patch("gevent.iwait", autospec=True, side_effect=TestException())
     def test_main_greenlet(self, m_iwait, m_IptablesUpdater, m_start, m_load,
-                           m_ipset_4):
+                           m_ipset_4, m_check_call, m_iface_exists,
+                           m_iface_up):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
         m_config = mock.Mock(spec=config.Config)
         m_config.HOSTNAME = "myhost"
         m_config.IFACE_PREFIX = "tap"
-        m_config.METADATA_IP = None
-        m_config.IP_IN_IP_ENABLED = False
-        m_config.IP_IN_IP_TUNNEL_NAME = "tunl0"
+        m_config.METADATA_IP = "10.0.0.1"
+        m_config.METADATA_PORT = 1234
+        m_config.IP_IN_IP_ENABLED = True
         with gevent.Timeout(5):
             self.assertRaises(TestException,
                               felix._main_greenlet, m_config)
-        m_load.assert_called_once_with(async=False)
+        m_load.assert_called_once_with(mock.ANY, async=False)
+        m_iface_exists.assert_called_once_with("tunl0")
+        m_iface_up.assert_called_once_with("tunl0")

--- a/calico/felix/test/test_ipsets.py
+++ b/calico/felix/test/test_ipsets.py
@@ -24,8 +24,8 @@ import logging
 from mock import *
 from calico.datamodel_v1 import EndpointId
 from calico.felix.futils import IPV4, FailedSystemCall
-from calico.felix.ipsets import IpsetManager, ActiveIpset, EndpointData, \
-    EMPTY_ENDPOINT_DATA
+from calico.felix.ipsets import (EndpointData,  IpsetManager, TagIpset,
+                                 EMPTY_ENDPOINT_DATA)
 from calico.felix.refcount import CREATED
 from calico.felix.test.base import BaseTestCase
 
@@ -78,7 +78,7 @@ class TestIpsetManager(BaseTestCase):
         self.mgr._create = self.m_create
 
     def m_create(self, tag_id):
-        ipset = Mock(spec=ActiveIpset)
+        ipset = Mock(spec=TagIpset)
 
         ipset._manager = None
         ipset._id = None

--- a/calico/felix/test/test_ipsets.py
+++ b/calico/felix/test/test_ipsets.py
@@ -25,7 +25,7 @@ from mock import *
 from calico.datamodel_v1 import EndpointId
 from calico.felix.futils import IPV4, FailedSystemCall
 from calico.felix.ipsets import (EndpointData,  IpsetManager, TagIpset,
-                                 EMPTY_ENDPOINT_DATA)
+                                 EMPTY_ENDPOINT_DATA, Ipset)
 from calico.felix.refcount import CREATED
 from calico.felix.test.base import BaseTestCase
 
@@ -424,3 +424,44 @@ class TestEndpointData(BaseTestCase):
 
     def test_really_a_struct(self):
         self.assertFalse(hasattr(EP_DATA_1_1, "__dict__"))
+
+
+class TestIpset(BaseTestCase):
+    def setUp(self):
+        super(TestIpset, self).setUp()
+        self.ipset = Ipset("foo", "foo-tmp", "inet")
+
+    @patch("calico.felix.futils.check_call", autospec=True)
+    def test_mainline(self, m_check_call):
+        self.ipset.replace_members(set(["10.0.0.1", "10.0.0.2"]))
+        m_check_call.assert_called_once_with(
+            ["ipset", "restore"],
+            input_str='create foo hash:ip family inet --exist\n'
+                      'create foo-tmp hash:ip family inet --exist\n'
+                      'flush foo-tmp\n'
+                      'add foo-tmp 10.0.0.1\n'
+                      'add foo-tmp 10.0.0.2\n'
+                      'swap foo foo-tmp\n'
+                      'destroy foo-tmp\n'
+                      'COMMIT\n'
+        )
+
+    @patch("calico.felix.futils.check_call", autospec=True)
+    def test_ensure_exists(self, m_check_call):
+        self.ipset.ensure_exists()
+        m_check_call.assert_called_once_with(
+            ["ipset", "restore"],
+            input_str='create foo hash:ip family inet --exist\n'
+                      'COMMIT\n'
+        )
+
+    @patch("calico.felix.futils.call_silent", autospec=True)
+    def test_delete(self, m_call_silent):
+        self.ipset.delete()
+        self.assertEqual(
+            m_call_silent.mock_calls,
+            [
+                call(["ipset", "destroy", "foo"]),
+                call(["ipset", "destroy", "foo-tmp"]),
+            ]
+        )

--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -23,7 +23,7 @@ import logging
 from subprocess import CalledProcessError
 from mock import Mock, call
 from calico.felix.fiptables import IptablesUpdater
-from calico.felix.ipsets import IpsetManager, ActiveIpset
+from calico.felix.ipsets import IpsetManager, TagIpset
 from calico.felix.profilerules import ProfileRules, RulesManager
 
 from calico.felix.test.base import BaseTestCase
@@ -268,8 +268,8 @@ class TestProfileRules(BaseTestCase):
             obj_id = args[0]
             callback = kwargs["callback"]
             seen_tags.add(obj_id)
-            m_ipset = Mock(spec=ActiveIpset)
-            m_ipset.name = obj_id + "-name"
+            m_ipset = Mock(spec=TagIpset)
+            m_ipset.ipset_name = obj_id + "-name"
             callback(obj_id, m_ipset)
             self.step_actor(self.rules)
         self.m_ips_mgr.get_and_incref.reset_mock()


### PR DESCRIPTION
Allows Calico to be evaluated without reconfiguring the underlying fabric to peer with Calico.

This is split into two commits, the first does some refactoring to make it easier to re-use the ipsets code.