### PR TITLE
Allow 0 as a valid port for match rules.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   objects.
 - Allow different hosts to have different interface prefixes for combined
   OpenStack and Docker systems.
+- Add missing support for 0 as a TCP port.
 
 ## 0.23
 

--- a/calico/common.py
+++ b/calico/common.py
@@ -494,7 +494,7 @@ def validate_rule_port(port):
     :returns: None or an error string if invalid
     """
     if isinstance(port, int):
-        if port < 1 or port > 65535:
+        if port < 0 or port > 65535:
             return "integer out of range"
         return None
 
@@ -513,7 +513,7 @@ def validate_rule_port(port):
     except ValueError:
         return "range invalid"
 
-    if start >= end or start < 1 or end > 65535:
+    if start >= end or start < 0 or end > 65535:
         return "range invalid"
 
     return None

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -62,16 +62,16 @@ RULES_TESTS = [
 
     ([{"protocol": "tcp",
        "src_tag": "tag-foo",
-       "src_ports": [10, "11:12"]}], 4,
+       "src_ports": ["0:12", 13]}], 4,
      ["--append chain-foo --protocol tcp "
       "--match set --match-set ipset-foo src "
-      "--match multiport --source-ports 10,11:12 --jump RETURN",
+      "--match multiport --source-ports 0:12,13 --jump RETURN",
       DEFAULT_MARK]),
 
     ([{"protocol": "tcp",
-       "src_ports": [1, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]}], 4,
+       "src_ports": [0, "2:3", 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]}], 4,
      ["--append chain-foo --protocol tcp "
-      "--match multiport --source-ports 1,2:3,4,5,6,7,8,9,10,11,12,13,14,15 "
+      "--match multiport --source-ports 0,2:3,4,5,6,7,8,9,10,11,12,13,14,15 "
       "--jump RETURN",
       "--append chain-foo --protocol tcp "
       "--match multiport --source-ports 16,17 "

--- a/calico/test/test_common.py
+++ b/calico/test/test_common.py
@@ -621,8 +621,8 @@ class TestCommon(unittest.TestCase):
     def test_validate_rule_port(self):
         self.assertEqual(common.validate_rule_port(73), None)
         self.assertEqual(common.validate_rule_port("57:123"), None)
-        self.assertEqual(common.validate_rule_port(0),
-                         "integer out of range")
+        self.assertEqual(common.validate_rule_port("0:1024"), None)
+        self.assertEqual(common.validate_rule_port(0), None)
         self.assertEqual(common.validate_rule_port(65536),
                          "integer out of range")
         self.assertEqual(common.validate_rule_port([]),
@@ -637,7 +637,7 @@ class TestCommon(unittest.TestCase):
                          "range invalid")
         self.assertEqual(common.validate_rule_port("3:1"),
                          "range invalid")
-        self.assertEqual(common.validate_rule_port("0:3"),
+        self.assertEqual(common.validate_rule_port("-1:3"),
                          "range invalid")
         self.assertEqual(common.validate_rule_port("5:65536"),
                          "range invalid")


### PR DESCRIPTION
Now we know iptables is happy with 0 for a port, just let it through.