### PR TITLE
Add IP masquerade support for private IPAM pools.

### DIFF
--- a/calico/common.py
+++ b/calico/common.py
@@ -87,7 +87,7 @@ VALID_LINUX_IFACE_NAME_RE = re.compile(r'^[a-zA-Z0-9_]{1,15}$')
 # Not that thorough: we don't care if it's a valid CIDR, only that it doesn't
 # have anything malicious in it.
 VALID_IPAM_POOL_ID_RE = re.compile(r'^[0-9\.:a-fA-F\-]{1,43}$')
-EXPECTED_IPAM_POOL_KEYS = set(["cidr", "ipip", "masquerade"])
+EXPECTED_IPAM_POOL_KEYS = set(["cidr", "masquerade"])
 
 tid_storage = gevent.local.local()
 tid_counter = itertools.count()
@@ -603,14 +603,6 @@ def validate_ipam_pool(pool_id, pool, ip_version):
             issues.append("Invalid CIDR: %r" % cidr)
         else:
             pool["cidr"] = canonicalise_cidr(cidr, ip_version)
-
-    if "ipip" in pool:
-        ipip_name = pool["ipip"]
-        if not isinstance("ipip", StringTypes):
-            issues.append("'ipip' field should be a string, not %r" %
-                          ipip_name)
-        elif not VALID_LINUX_IFACE_NAME_RE.match(ipip_name):
-            issues.append("Invalid interface name for 'ipip': %r" % ipip_name)
 
     if not isinstance(pool.get("masquerade", False), bool):
         issues.append("Invalid 'masquerade' field: %r" % pool["masquerade"])

--- a/calico/datamodel_v1.py
+++ b/calico/datamodel_v1.py
@@ -71,6 +71,9 @@ ENDPOINT_KEY_RE = re.compile(
 HOST_IP_KEY_RE = re.compile(r'^' + HOST_DIR +
                             r'/(?P<hostname>[^/]+)/bird_ip')
 
+IPAM_V4_CIDR_KEY_RE = re.compile(r'^' + VERSION_DIR +
+                                 r'/ipam/v4/pool/(?P<encoded_cidr>[^/]+)')
+
 def dir_for_host(hostname):
     return HOST_DIR+ "/%s" % hostname
 

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -126,7 +126,7 @@ def _main_greenlet(config):
             v4_filter_updater,
             v4_nat_updater,
             v4_ipset_mgr,
-            v4_masq_manager
+            v4_masq_manager,
             v4_rules_manager,
             v4_dispatch_chains,
             v4_ep_manager,

--- a/calico/felix/felix.py
+++ b/calico/felix/felix.py
@@ -45,6 +45,7 @@ from calico.felix.devices import InterfaceWatcher
 from calico.felix.endpoint import EndpointManager
 from calico.felix.fetcd import EtcdWatcher
 from calico.felix.ipsets import IpsetManager, IpsetActor, HOSTS_IPSET_V4
+from calico.felix.masq import MasqueradeManager
 
 _log = logging.getLogger(__name__)
 
@@ -69,6 +70,7 @@ def _main_greenlet(config):
         v4_filter_updater = IptablesUpdater("filter", ip_version=4)
         v4_nat_updater = IptablesUpdater("nat", ip_version=4)
         v4_ipset_mgr = IpsetManager(IPV4)
+        v4_masq_manager = MasqueradeManager(IPV4, v4_nat_updater)
         v4_rules_manager = RulesManager(4, v4_filter_updater, v4_ipset_mgr)
         v4_dispatch_chains = DispatchChains(config, 4, v4_filter_updater)
         v4_ep_manager = EndpointManager(config,
@@ -91,7 +93,9 @@ def _main_greenlet(config):
                                          [v4_ipset_mgr, v6_ipset_mgr],
                                          [v4_rules_manager, v6_rules_manager],
                                          [v4_ep_manager, v6_ep_manager],
-                                         [v4_filter_updater, v6_filter_updater])
+                                         [v4_filter_updater,
+                                          v6_filter_updater],
+                                         v4_masq_manager)
         iface_watcher = InterfaceWatcher(update_splitter)
 
         _log.info("Starting actors.")
@@ -101,6 +105,7 @@ def _main_greenlet(config):
         v4_filter_updater.start()
         v4_nat_updater.start()
         v4_ipset_mgr.start()
+        v4_masq_manager.start()
         v4_rules_manager.start()
         v4_dispatch_chains.start()
         v4_ep_manager.start()
@@ -121,6 +126,7 @@ def _main_greenlet(config):
             v4_filter_updater,
             v4_nat_updater,
             v4_ipset_mgr,
+            v4_masq_manager
             v4_rules_manager,
             v4_dispatch_chains,
             v4_ep_manager,
@@ -132,7 +138,7 @@ def _main_greenlet(config):
             v6_ep_manager,
 
             iface_watcher,
-            etcd_watcher
+            etcd_watcher,
         ]
         monitored_items = [actor.greenlet for actor in top_level_actors]
 

--- a/calico/felix/fiptables.py
+++ b/calico/felix/fiptables.py
@@ -98,7 +98,7 @@ class IptablesUpdater(Actor):
 
     def __init__(self, table, ip_version=4):
         super(IptablesUpdater, self).__init__(qualifier="v%d" % ip_version)
-        self._table = table
+        self.table = table
         if ip_version == 4:
             self._restore_cmd = "iptables-restore"
             self._save_cmd = "iptables-save"
@@ -158,8 +158,8 @@ class IptablesUpdater(Actor):
     def _refresh_chains_in_dataplane(self):
         self._stats.increment("Refreshed chain list")
         raw_ipt_output = subprocess.check_output([self._save_cmd, "--table",
-                                                  self._table])
-        self._chains_in_dataplane = _extract_our_chains(self._table,
+                                                  self.table])
+        self._chains_in_dataplane = _extract_our_chains(self.table,
                                                         raw_ipt_output)
 
     def _read_unreferenced_chains(self):
@@ -170,7 +170,7 @@ class IptablesUpdater(Actor):
             are not referenced by other chains.
         """
         raw_ipt_output = subprocess.check_output(
-            [self._iptables_cmd, "--wait", "--list", "--table", self._table])
+            [self._iptables_cmd, "--wait", "--list", "--table", self.table])
         return _extract_our_unreffed_chains(raw_ipt_output)
 
     @actor_message()
@@ -223,7 +223,7 @@ class IptablesUpdater(Actor):
             # exists then the rule will be moved to the start of the chain.
             _log.info("Attempting to move any existing instance of rule %r"
                       "to top of chain.", rule_fragment)
-            self._execute_iptables(['*%s' % self._table,
+            self._execute_iptables(['*%s' % self.table,
                                     '--delete %s' % rule_fragment,
                                     '--insert %s' % rule_fragment,
                                     'COMMIT'],
@@ -232,7 +232,7 @@ class IptablesUpdater(Actor):
             # Assume the rule didn't exist. Try inserting it.
             _log.info("Didn't find any existing instance of rule %r, "
                       "inserting it instead.")
-            self._execute_iptables(['*%s' % self._table,
+            self._execute_iptables(['*%s' % self.table,
                                     '--insert %s' % rule_fragment,
                                     'COMMIT'])
 
@@ -487,7 +487,7 @@ class IptablesUpdater(Actor):
             input_lines.extend(chain_updates)
         if not input_lines:
             raise NothingToDo
-        return ["*%s" % self._table] + input_lines + ["COMMIT"]
+        return ["*%s" % self.table] + input_lines + ["COMMIT"]
 
     def _calculate_ipt_delete_input(self, chains):
         """
@@ -498,7 +498,7 @@ class IptablesUpdater(Actor):
         """
         input_lines = []
         found_delete = False
-        input_lines.append("*%s" % self._table)
+        input_lines.append("*%s" % self.table)
         for chain_name in chains:
             # Delete the chain
             input_lines.append(":%s -" % chain_name)
@@ -516,7 +516,7 @@ class IptablesUpdater(Actor):
         """
         input_lines = []
         found_chain_to_stub = False
-        input_lines.append("*%s" % self._table)
+        input_lines.append("*%s" % self.table)
         for chain_name in chains:
             # Stub the chain
             input_lines.append(":%s -" % chain_name)

--- a/calico/felix/ipsets.py
+++ b/calico/felix/ipsets.py
@@ -634,6 +634,18 @@ class Ipset(object):
         assert ip_family in ("inet", "inet6")
         self.family = ip_family
 
+    def exists(self):
+        try:
+            futils.check_call(["ipset", "list", self.set_name])
+        except FailedSystemCall as e:
+            if e.retcode == 1 and "does not exist" in e.stderr:
+                return False
+            else:
+                _log.exception("Failed to check if ipset exists")
+                raise
+        else:
+            return True
+
     def ensure_exists(self):
         """
         Creates the ipset iff it does not exist.

--- a/calico/felix/masq.py
+++ b/calico/felix/masq.py
@@ -1,0 +1,86 @@
+# Copyright (c) Metaswitch Networks 2015. All rights reserved.
+
+import logging
+from calico.felix.actor import Actor, actor_message
+from calico.felix.futils import IPV4, IPV6
+from calico.felix.ipsets import Ipset, FELIX_PFX
+
+_log = logging.getLogger(__name__)
+
+
+ALL_POOLS_SET_NAME = FELIX_PFX + "all-ipam-pools"
+MASQ_POOLS_SET_NAME = FELIX_PFX + "masq-ipam-pools"
+
+
+class MasqueradeManager(Actor):
+    def __init__(self, ip_type, iptables_mgr):
+        super(MasqueradeManager, self).__init__(qualifier=str(ip_type))
+        assert ip_type in (IPV4, IPV6)
+        assert iptables_mgr.table == "nat"
+        self.ip_type = ip_type
+        self.pools_by_id = {}
+        self._iptables_mgr = iptables_mgr
+        ip_family = "inet" if ip_type == IPV4 else "inet6"
+        self._all_pools_ipset = Ipset(ALL_POOLS_SET_NAME,
+                                      ALL_POOLS_SET_NAME + "-tmp",
+                                      ip_family,
+                                      "hash:net")
+        self._masq_pools_ipset = Ipset(MASQ_POOLS_SET_NAME,
+                                       MASQ_POOLS_SET_NAME + "-tmp",
+                                       ip_family,
+                                       "hash:net")
+        self._dirty = False
+        self._install_rules(async=True)
+
+    @actor_message()
+    def _install_rules(self):
+        # Can't program a rule before we create a ipset but we won't know what
+        # to put in the ipset until we hear about it.
+        self._all_pools_ipset.ensure_exists()
+        self._masq_pools_ipset.ensure_exists()
+        # Enable masquerading for traffic coming from pools that have it
+        # enabled only when the traffic is heading to an IP that isn't in any
+        # Calico-owned pool.  (We assume that NAT is not required for
+        # Calico-owned IPs.)
+        self._iptables_mgr.ensure_rule_inserted(
+            "POSTROUTING "
+            "--match set --match-set %s src "
+            "--match set ! --match-set %s dst "
+            "--jump MASQUERADE" % (MASQ_POOLS_SET_NAME,
+                                   ALL_POOLS_SET_NAME),
+            async=True
+        )
+
+    @actor_message()
+    def apply_snapshot(self, pools_by_id):
+        _log.info("Applying IPAM pool snapshot with %s pools",
+                  len(pools_by_id))
+        self.pools_by_id.clear()
+        self.pools_by_id.update(pools_by_id)
+        self._dirty = True
+
+    @actor_message()
+    def on_ipam_pool_updated(self, pool_id, pool):
+        if self.pools_by_id.get(pool_id) != pool:
+            if pool is None:
+                _log.info("IPAM pool deleted: %s", pool_id)
+                del self.pools_by_id[pool_id]
+            else:
+                _log.info("IPAM pool %s updated: %s", pool_id, pool)
+                self.pools_by_id[pool_id] = pool
+            self._dirty = True
+
+    def _finish_msg_batch(self, batch, results):
+        _log.debug("Finishing batch of IPAM pool changes")
+        if self._dirty:
+            _log.info("Marked as dirty, refreshing ipsets")
+            masq_enabled_cidrs = set()
+            all_cidrs = set()
+            for pool in self.pools_by_id.itervalues():
+                all_cidrs.add(pool["cidr"])
+                if pool.get("masquerade", False):
+                    masq_enabled_cidrs.add(pool["cidr"])
+            self._all_pools_ipset.replace_members(all_cidrs)
+            self._masq_pools_ipset.replace_members(masq_enabled_cidrs)
+            self._dirty = False
+            _log.info("Finished refreshing ipsets")

--- a/calico/felix/splitter.py
+++ b/calico/felix/splitter.py
@@ -33,18 +33,19 @@ class UpdateSplitter(Actor):
     and IPv6-specific actors.
     """
     def __init__(self, config, ipsets_mgrs, rules_managers, endpoint_managers,
-                 iptables_updaters):
+                 iptables_updaters, ipv4_nat_manager):
         super(UpdateSplitter, self).__init__()
         self.config = config
         self.ipsets_mgrs = ipsets_mgrs
         self.iptables_updaters = iptables_updaters
         self.rules_mgrs = rules_managers
         self.endpoint_mgrs = endpoint_managers
+        self.ipv4_nat_manager = ipv4_nat_manager
         self._cleanup_scheduled = False
 
     @actor_message()
     def apply_snapshot(self, rules_by_prof_id, tags_by_prof_id,
-                       endpoints_by_id):
+                       endpoints_by_id, ipv4_pools_by_id):
         """
         Replaces the whole cache state with the input.  Applies deltas vs the
         current active state.
@@ -55,22 +56,27 @@ class UpdateSplitter(Actor):
             profile tags.
         :param endpoints_by_id: A dict mapping EndpointId objects to endpoint
             data dicts.
+        :param ipv4_pools_by_id: A dict mapping IPAM pool ID to dicts
+            representing the pool.
         """
         # Step 1: fire in data update events to the profile and tag managers
         # so they can build their indexes before we activate anything.
-        _log.info("Applying snapshot. STAGE 1a: rules.")
+        _log.info("Applying snapshot. Queueing rules.")
         for rules_mgr in self.rules_mgrs:
             rules_mgr.apply_snapshot(rules_by_prof_id, async=True)
-        _log.info("Applying snapshot. STAGE 1b: tags.")
+        _log.info("Applying snapshot. Queueing tags/endpoints to ipset mgr.")
         for ipset_mgr in self.ipsets_mgrs:
             ipset_mgr.apply_snapshot(tags_by_prof_id, endpoints_by_id,
                                      async=True)
 
         # Step 2: fire in update events into the endpoint manager, which will
         # recursively trigger activation of profiles and tags.
-        _log.info("Applying snapshot. STAGE 2: endpoints->endpoint mgr.")
+        _log.info("Applying snapshot. Queueing endpoints->endpoint mgr.")
         for ep_mgr in self.endpoint_mgrs:
             ep_mgr.apply_snapshot(endpoints_by_id, async=True)
+
+        # Step 3: send update to NAT manager.
+        self.ipv4_nat_manager.apply_snapshot(ipv4_pools_by_id, async=True)
 
         _log.info("Applying snapshot. DONE. %s rules, %s tags, "
                   "%s endpoints", len(rules_by_prof_id), len(tags_by_prof_id),
@@ -153,3 +159,8 @@ class UpdateSplitter(Actor):
             ipset_mgr.on_endpoint_update(endpoint_id, endpoint, async=True)
         for endpoint_mgr in self.endpoint_mgrs:
             endpoint_mgr.on_endpoint_update(endpoint_id, endpoint, async=True)
+
+    @actor_message()
+    def on_ipam_pool_update(self, pool_id, pool):
+        _log.info("IPAM pool %s updated", pool_id)
+        self.ipv4_nat_manager.on_ipam_pool_updated(pool_id, pool, async=True)

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -59,11 +59,14 @@ class TestBasic(BaseTestCase):
     @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config", autospec=True)
     @mock.patch("gevent.Greenlet.start", autospec=True)
     @mock.patch("calico.felix.felix.IptablesUpdater", autospec=True)
+    @mock.patch("calico.felix.felix.MasqueradeManager", autospec=True)
     @mock.patch("gevent.iwait", autospec=True, side_effect=TestException())
-    def test_main_greenlet(self, m_iwait, m_IptablesUpdater, m_start, m_load,
+    def test_main_greenlet(self, m_iwait, m_MasqueradeManager,
+                           m_IptablesUpdater, m_start, m_load,
                            m_ipset_4, m_check_call, m_iface_exists,
                            m_iface_up):
         m_IptablesUpdater.return_value.greenlet = mock.Mock()
+        m_MasqueradeManager.return_value.greenlet = mock.Mock()
         m_config = mock.Mock(spec=config.Config)
         m_config.HOSTNAME = "myhost"
         m_config.IFACE_PREFIX = "tap"

--- a/calico/felix/test/test_masq.py
+++ b/calico/felix/test/test_masq.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+felix.test.test_masq
+~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for the MasqueradeManager.
+"""
+from collections import defaultdict
+
+import logging
+from mock import *
+from calico.felix.fiptables import IptablesUpdater
+from calico.felix.masq import *
+
+# Logger
+from calico.felix.test.base import BaseTestCase
+
+_log = logging.getLogger(__name__)
+
+
+class TestMasqueradeManager(BaseTestCase):
+    def setUp(self):
+        super(TestMasqueradeManager, self).setUp()
+        self.m_iptables_mgr = Mock(spec=IptablesUpdater)
+        self.m_iptables_mgr.table = "nat"
+        with patch("calico.felix.masq.Ipset", autospec=True) as m_Ipset:
+            self.masq_mgr = MasqueradeManager(IPV4, self.m_iptables_mgr)
+            _log.info("Ipset calls: %s", m_Ipset.mock_calls)
+            m_Ipset.assert_has_calls([
+                call("felix-all-ipam-pools", "felix-all-ipam-pools-tmp",
+                     "inet", "hash:net"),
+                call("felix-masq-ipam-pools", "felix-masq-ipam-pools-tmp",
+                     "inet", "hash:net"),
+            ])
+        self.m_all_pools = Mock(spec=Ipset)
+        self.m_masq_pools = Mock(spec=Ipset)
+        self.masq_mgr._all_pools_ipset = self.m_all_pools
+        self.masq_mgr._masq_pools_ipset = self.m_masq_pools
+
+    def test_apply_snapshot_empty(self):
+        self.m_all_pools.exists.return_value = True
+        self.m_masq_pools.exists.return_value = True
+        self.masq_mgr.apply_snapshot({}, async=True)
+        self.step_actor(self.masq_mgr)
+        self.m_iptables_mgr.ensure_rule_removed.assert_called_once_with(
+            "POSTROUTING "
+            "--match set --match-set felix-masq-ipam-pools src "
+            "--match set ! --match-set felix-all-ipam-pools dst "
+            "--jump MASQUERADE",
+            async=False
+        )
+        self.m_all_pools.delete.assert_called_once_with()
+        self.m_masq_pools.delete.assert_called_once_with()
+
+    def test_apply_snapshot_no_masq_pools(self):
+        self.m_all_pools.exists.return_value = True
+        self.m_masq_pools.exists.return_value = False
+        self.masq_mgr.apply_snapshot({"foo": {"cidr": "10.0.0.0/16"}},
+                                     async=True)
+        self.step_actor(self.masq_mgr)
+        self.assertFalse(self.m_iptables_mgr.ensure_rule_removed.called)
+        self.m_all_pools.delete.assert_called_once_with()
+        self.m_masq_pools.delete.assert_called_once_with()
+
+    def test_apply_snapshot_with_masq_pools(self):
+        self.masq_mgr.apply_snapshot({"foo": {"cidr": "10.0.0.0/16",
+                                              "masquerade": True},
+                                      "bar": {"cidr": "10.1.0.0/16",
+                                              "masquerade": False}},
+                                     async=True)
+        self.step_actor(self.masq_mgr)
+        self.m_iptables_mgr.ensure_rule_inserted.assert_called_once_with(
+            "POSTROUTING "
+            "--match set --match-set felix-masq-ipam-pools src "
+            "--match set ! --match-set felix-all-ipam-pools dst "
+            "--jump MASQUERADE",
+            async=True
+        )
+        self.assertFalse(self.m_iptables_mgr.ensure_rule_removed.called)
+        self.m_all_pools.replace_members.assert_called_once_with(set([
+            "10.0.0.0/16",
+            "10.1.0.0/16",
+        ]))
+        self.m_masq_pools.replace_members.assert_called_once_with(set([
+            "10.0.0.0/16",
+        ]))
+
+    def test_update(self):
+        self.masq_mgr.apply_snapshot({"foo": {"cidr": "10.0.0.0/16",
+                                              "masquerade": True},
+                                      "bar": {"cidr": "10.1.0.0/16",
+                                              "masquerade": False}},
+                                     async=True)
+        # Delete
+        self.masq_mgr.on_ipam_pool_updated("foo", None, async=True)
+        # Update
+        self.masq_mgr.on_ipam_pool_updated("bar", {"cidr": "10.1.0.0/16",
+                                                   "masquerade": True},
+                                           async=True)
+        # New
+        self.masq_mgr.on_ipam_pool_updated("baz", {"cidr": "10.2.0.0/16",
+                                                   "masquerade": False},
+                                           async=True)
+        self.step_actor(self.masq_mgr)
+        self.m_all_pools.replace_members.assert_called_once_with(set([
+            "10.1.0.0/16",
+            "10.2.0.0/16",
+        ]))
+        self.m_masq_pools.replace_members.assert_called_once_with(set([
+            "10.1.0.0/16",
+        ]))


### PR DESCRIPTION
@plwhite / @ed-harrison  Please can you coordinate to get this reviewed on Friday?  It's a dependency for the high-priority work that the calico-docker team is doing so we'd like to get it into the 0.24 release.

The change is to have felix monitor calico-docker's IPAM pools, watching for a new "masquerade" flag on the pool and keeping an ipset up-to-date with the set of pools that have masquerading enabled.  It then programs an iptables rule to masquerade traffic that is coming from a masqueraded pool, going to any non-calico IP (i.e. one that's not in any pool).

This is pretty tactical and it's an unsupported feature that should have no impact on OpenStack.  one concern I have is that we're watching ipam/v4/pool/..., which seems a bit internal but I don't think we'll get this all together if we start changing that right now.

It could do with a few more comments and I'll write some UTs tomorrow if you're broadly happy with it.