### PR TITLE
Reinstate from-endpoint policy in INPUT chain

### DIFF
--- a/calico/felix/config.py
+++ b/calico/felix/config.py
@@ -173,6 +173,9 @@ class Config(object):
         self.add_parameter("MetadataPort", "Metadata Port",
                            8775, value_is_int=True)
         self.add_parameter("InterfacePrefix", "Interface name prefix", None)
+        self.add_parameter("DefaultEndpointToHostAction",
+                           "Action to take for packets that arrive from"
+                           "an endpoint to the host.", "DROP")
         self.add_parameter("LogFilePath",
                            "Path to log file", "/var/log/calico/felix.log")
         self.add_parameter("LogSeverityFile",
@@ -224,6 +227,8 @@ class Config(object):
         self.METADATA_IP = self.parameters["MetadataAddr"].value
         self.METADATA_PORT = self.parameters["MetadataPort"].value
         self.IFACE_PREFIX = self.parameters["InterfacePrefix"].value
+        self.DEFAULT_INPUT_CHAIN_ACTION = \
+            self.parameters["DefaultEndpointToHostAction"].value
         self.LOGFILE = self.parameters["LogFilePath"].value
         self.LOGLEVFILE = self.parameters["LogSeverityFile"].value
         self.LOGLEVSYS = self.parameters["LogSeveritySys"].value
@@ -359,6 +364,12 @@ class Config(object):
                 raise ConfigException("Invalid field value",
                                       self.parameters["MetadataPort"])
 
+        if self.DEFAULT_INPUT_CHAIN_ACTION not in ("DROP", "RETURN", "ACCEPT"):
+            raise ConfigException(
+                "Invalid field value",
+                self.parameters["DefaultEndpointToHostAction"]
+            )
+
         if not final:
             # Do not check that unset parameters are defaulted; we have more
             # config to read.
@@ -375,7 +386,6 @@ class Config(object):
         for lKey in cfg_dict:
             log.warning("Got unexpected config item %s=%s",
                         lKey, cfg_dict[lKey])
-
 
     def _validate_addr(self, name, addr):
         """

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -400,6 +400,19 @@ def _build_input_chain(iface_match, metadata_addr, metadata_port,
         (CHAIN_INPUT, iface_match, dhcp_src_port, dhcp_dst_port)
     )
 
+    if default_action != "DROP":
+        # Optimisation: the from-ENDPOINT chain signals acceptance of a packet
+        # by RETURNing.  If we're going to drop the packet anyway, don't
+        # bother applying the from-ENDPOINT chain.
+        _log.info("Default endpoint->host action set to %s, felix will apply"
+                  "per-endpoint policy to packets in the INPUT chain.",
+                  default_action)
+        chain.append(
+            "--append %s --jump %s --in-interface %s" %
+            (CHAIN_INPUT, CHAIN_FROM_ENDPOINT, iface_match)
+        )
+        deps.add(CHAIN_FROM_ENDPOINT)
+
     chain.append(
         "--append %s --in-interface %s --jump %s" %
         (CHAIN_INPUT, iface_match, default_action)

--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -73,6 +73,7 @@ class TestBasic(BaseTestCase):
         m_config.METADATA_IP = "10.0.0.1"
         m_config.METADATA_PORT = 1234
         m_config.IP_IN_IP_ENABLED = True
+        m_config.DEFAULT_INPUT_CHAIN_ACTION = "RETURN"
         with gevent.Timeout(5):
             self.assertRaises(TestException,
                               felix._main_greenlet, m_config)


### PR DESCRIPTION
Reinstate the jump to the felix-FROM-ENDPOINT chain for traffic from endpoints going to the host.  This allows a host's outbound policy to limit its outgoing traffic before it reaches the host.

Make the action for packets that are accepted by the felix-FROM-ENDPOINT chain configurable so that a knowledgable operator can implement their own policy after felix's

Fixes #659 Fixes #660 