### PR TITLE
Refactor etcd watcher: split off dedicated polling greenlet.

### DIFF
--- a/calico/felix/test/test_felix.py
+++ b/calico/felix/test/test_felix.py
@@ -56,7 +56,7 @@ class TestBasic(BaseTestCase):
                 return_value=False, autospec=True)
     @mock.patch("calico.felix.futils.check_call", autospec=True)
     @mock.patch("calico.felix.frules.HOSTS_IPSET_V4", autospec=True)
-    @mock.patch("calico.felix.fetcd.EtcdWatcher.load_config", autospec=True)
+    @mock.patch("calico.felix.fetcd.EtcdAPI.load_config")
     @mock.patch("gevent.Greenlet.start", autospec=True)
     @mock.patch("calico.felix.felix.IptablesUpdater", autospec=True)
     @mock.patch("calico.felix.felix.MasqueradeManager", autospec=True)
@@ -77,6 +77,6 @@ class TestBasic(BaseTestCase):
         with gevent.Timeout(5):
             self.assertRaises(TestException,
                               felix._main_greenlet, m_config)
-        m_load.assert_called_once_with(mock.ANY, async=False)
+        m_load.assert_called_once_with(async=False)
         m_iface_exists.assert_called_once_with("tunl0")
         m_iface_up.assert_called_once_with("tunl0")

--- a/calico/felix/test/test_fetcd.py
+++ b/calico/felix/test/test_fetcd.py
@@ -5,8 +5,8 @@ import logging
 from etcd import EtcdResult
 from mock import Mock, call
 from calico.datamodel_v1 import EndpointId
-from calico.felix.fetcd import EtcdWatcher, ResyncRequired
 from calico.felix.ipsets import IpsetActor
+from calico.felix.fetcd import _EtcdWatcher, ResyncRequired
 from calico.felix.splitter import UpdateSplitter
 from calico.felix.test.base import BaseTestCase
 
@@ -44,7 +44,7 @@ class TestExcdWatcher(BaseTestCase):
         self.m_config = Mock()
         self.m_config.IFACE_PREFIX = "tap"
         self.m_hosts_ipset = Mock(spec=IpsetActor)
-        self.watcher = EtcdWatcher(self.m_config, self.m_hosts_ipset)
+        self.watcher = _EtcdWatcher(self.m_config, self.m_hosts_ipset)
         self.m_splitter = Mock(spec=UpdateSplitter)
         self.watcher.splitter = self.m_splitter
 
@@ -199,7 +199,7 @@ class TestExcdWatcher(BaseTestCase):
         self.m_splitter.on_tags_update.assert_called_once_with("profA", None,
                                                                async=True)
         self.m_splitter.on_rules_update.assert_called_once_with("profA", None,
-                                                               async=True)
+                                                                async=True)
 
     def test_tags_del(self):
         """
@@ -216,7 +216,7 @@ class TestExcdWatcher(BaseTestCase):
         """
         self.dispatch("/calico/v1/policy/profile/profA/rules", action="delete")
         self.m_splitter.on_rules_update.assert_called_once_with("profA", None,
-                                                               async=True)
+                                                                async=True)
         self.assertFalse(self.m_splitter.on_tags_update.called)
 
     def test_endpoint_del(self):


### PR DESCRIPTION
@plwhite I split out the refactoring part of the WiP on periodic resync.  I think it's sound on its own and it's needed for @joe-marshall's work to implement status reporting.