### PR TITLE
Fix that profile chains weren't being stubbed out.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.25-dev
 
+- #672: Fix bug where profile chain was left empty instead of being 
+  stubbed out.
 - Improve security between endpoint and host and simplify INPUT chain logic.
 
 ## 0.24

--- a/calico/felix/devices.py
+++ b/calico/felix/devices.py
@@ -28,8 +28,6 @@ from calico import common
 from calico.felix import futils
 
 # Logger
-import re
-
 _log = logging.getLogger(__name__)
 
 

--- a/calico/felix/endpoint.py
+++ b/calico/felix/endpoint.py
@@ -20,7 +20,6 @@ felix.endpoint
 Endpoint management.
 """
 import logging
-from subprocess import CalledProcessError
 from calico.felix import devices, futils
 from calico.felix.actor import actor_message
 from calico.felix.futils import FailedSystemCall
@@ -349,7 +348,7 @@ class LocalEndpoint(RefCountedActor):
         )
         try:
             self.iptables_updater.rewrite_chains(updates, deps, async=False)
-        except CalledProcessError:
+        except FailedSystemCall:
             _log.exception("Failed to program chains for %s. Removing.", self)
             self._failed = True
             self._remove_chains()
@@ -358,7 +357,7 @@ class LocalEndpoint(RefCountedActor):
         try:
             self.iptables_updater.delete_chains(chain_names(self._suffix),
                                                 async=True)
-        except CalledProcessError:
+        except FailedSystemCall:
             _log.exception("Failed to delete chains for %s", self)
             self._failed = True
 
@@ -390,7 +389,7 @@ class LocalEndpoint(RefCountedActor):
                                self.endpoint["mac"],
                                reset_arp=reset_arp)
 
-        except (IOError, FailedSystemCall, CalledProcessError):
+        except (IOError, FailedSystemCall):
             if not devices.interface_exists(self._iface_name):
                 _log.info("Interface %s for %s does not exist yet",
                           self._iface_name, self.combined_id)
@@ -408,7 +407,7 @@ class LocalEndpoint(RefCountedActor):
         """
         try:
             devices.set_routes(self.ip_type, set(), self._iface_name, None)
-        except (IOError, FailedSystemCall, CalledProcessError):
+        except (IOError, FailedSystemCall):
             if not devices.interface_exists(self._iface_name):
                 # Deleted under our feet - so the rules are gone.
                 _log.debug("Interface %s for %s deleted",

--- a/calico/felix/fiptables.py
+++ b/calico/felix/fiptables.py
@@ -186,7 +186,7 @@ class IptablesUpdater(Actor):
         :param dependent_chains: map from chain name to a set of chains
                that that chain requires to exist. They will be created
                (with a default drop) if they don't exist.
-        :returns CalledProcessError if a problem occurred.
+        :raises FailedSystemCall if a problem occurred.
         """
         # We actually apply the changes in _finish_msg_batch().  Index the
         # changes by table and chain.
@@ -270,6 +270,11 @@ class IptablesUpdater(Actor):
 
     @actor_message()
     def delete_chains(self, chain_names, callback=None):
+        """
+        Deletes the named chains.
+
+        :raises FailedSystemCall if a problem occurred.
+        """
         # We actually apply the changes in _finish_msg_batch().  Index the
         # changes by table and chain.
         _log.info("Deleting chains %s", chain_names)

--- a/calico/felix/profilerules.py
+++ b/calico/felix/profilerules.py
@@ -98,9 +98,9 @@ class ProfileRules(RefCountedActor):
         self._iptables_updater = iptables_updater
         self._ipset_refs = RefHelper(self, ipset_mgr, self._on_ipsets_acquired)
 
-        # Latest profile update.
+        # Latest profile update - a profile dictionary.
         self._pending_profile = None
-        # Currently-programmed profile.
+        # Currently-programmed profile dictionary.
         self._profile = None
 
         # State flags.
@@ -121,6 +121,9 @@ class ProfileRules(RefCountedActor):
         """
         Update the programmed iptables configuration with the new
         profile.
+
+        :param dict[str]|NoneType profile: Dictionary of all profile data or
+            None if profile is to be deleted.
         """
         _log.debug("%s: Profile update: %s", self, profile)
         assert not self._dead, "Shouldn't receive updates after we're dead."
@@ -225,9 +228,13 @@ class ProfileRules(RefCountedActor):
 
         Blocks until the update is complete.
 
+        On entry, self._pending_profile must not be None.
+
         :raises FailedSystemCall: if the update fails.
         """
         _log.info("%s Programming iptables with our chains.", self)
+        assert self._pending_profile is not None, \
+               "_update_chains called with no _pending_profile"
         updates = {}
         for direction in ("inbound", "outbound"):
             chain_name = self.chain_names[direction]

--- a/calico/felix/profilerules.py
+++ b/calico/felix/profilerules.py
@@ -20,10 +20,10 @@ ProfileRules actor, handles local profile chains.
 """
 
 import logging
-from subprocess import CalledProcessError
 from calico.felix.actor import actor_message
 from calico.felix.frules import (profile_to_chain_name,
                                  rules_to_chain_rewrite_lines)
+from calico.felix.futils import FailedSystemCall
 from calico.felix.refcount import ReferenceManager, RefCountedActor, RefHelper
 
 _log = logging.getLogger(__name__)
@@ -160,10 +160,7 @@ class ProfileRules(RefCountedActor):
             if not self._cleaned_up:
                 try:
                     _log.info("%s unreferenced, removing our chains", self)
-                    chains = set(self.chain_names.values())
-                    # Need to block here: have to wait for chains to be deleted
-                    # before we can decref our ipsets.
-                    self._iptables_updater.delete_chains(chains, async=False)
+                    self._delete_chains()
                     self._ipset_refs.discard_all()
                     self._ipset_refs = None # Break ref cycle.
                     self._profile = None
@@ -187,24 +184,48 @@ class ProfileRules(RefCountedActor):
                 self._dirty = True
                 self._profile = self._pending_profile
 
-            if self._dirty and self._ipset_refs.ready:
+            if (self._dirty and
+                    self._ipset_refs.ready and
+                    self._pending_profile is not None):
                 _log.info("Ready to program rules for %s", self.id)
                 try:
                     self._update_chains()
-                except CalledProcessError as e:
+                except FailedSystemCall as e:
                     _log.error("Failed to program profile chain %s; error: %r",
                                self, e)
                 else:
                     self._dirty = False
             elif not self._dirty:
                 _log.debug("No changes to program.")
+            elif self._pending_profile is None:
+                _log.info("Profile is None, removing our chains")
+                try:
+                    self._delete_chains()
+                except FailedSystemCall:
+                    _log.exception("Failed to delete chains for profile %s",
+                                   self.id)
+                else:
+                    self._dirty = False
             elif not self._ipset_refs.ready:
                 _log.info("Can't program rules %s yet, waiting on ipsets",
                           self.id)
 
+    def _delete_chains(self):
+        """
+        Removes our chains from the dataplane, blocks until complete.
+        """
+        chains = set(self.chain_names.values())
+        # Need to block here: have to wait for chains to be deleted
+        # before we can decref our ipsets.
+        self._iptables_updater.delete_chains(chains, async=False)
+
     def _update_chains(self):
         """
         Updates the chains in the dataplane.
+
+        Blocks until the update is complete.
+
+        :raises FailedSystemCall: if the update fails.
         """
         _log.info("%s Programming iptables with our chains.", self)
         updates = {}
@@ -213,9 +234,8 @@ class ProfileRules(RefCountedActor):
             _log.info("Updating %s chain %r for profile %s",
                       direction, chain_name, self.id)
             _log.debug("Profile %s: %s", self.id, self._profile)
-            new_profile = self._pending_profile or {}
             rules_key = "%s_rules" % direction
-            new_rules = new_profile.get(rules_key, [])
+            new_rules = self._pending_profile.get(rules_key, [])
             tag_to_ip_set_name = {}
             for tag, ipset in self._ipset_refs.iteritems():
                 tag_to_ip_set_name[tag] = ipset.ipset_name

--- a/calico/felix/test/test_profilerules.py
+++ b/calico/felix/test/test_profilerules.py
@@ -281,6 +281,14 @@ class TestProfileRules(BaseTestCase):
             set(['felix-p-prof1-i', 'felix-p-prof1-o']), async=False
         )
 
+    def test_update_chains_no_pending(self):
+        """
+        _update_chains requires _pending_profile not to be None.
+        """
+        with self.assertRaisesRegexp(AssertionError,
+                                     "called with no _pending_profile"):
+            self.rules._update_chains()
+
     def _process_ipset_refs(self, expected_tags):
         """
         Issues callbacks for all the mock calls to the mock ipset manager's


### PR DESCRIPTION
Spotted while live testing calico-docker with a bad profile that failed validation.

* When a profile chain was deleted or failed validation, we were aliasing that to {}, which is the empty chain, instead of deleting the chain.
* Spotted that we were still catching CalledProcessError instead of FailedSystemCall in a few places, fixed those up.
* Fixed up some comments and docstrings.

Impact is that, if you have multiple profiles attached to an endpoint and you're using an early chain for deny rules followed by more broad accept rules and the deny rules failed validation then the deny rules would be ignored rather than being replaced with a safe stub chain.