### PR TITLE
Streamline conntrack rules, move to top-level chains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 0.26-dev
 
+- Streamline conntrack rules, move them to top-level chains to avoid 
+  duplication.
+- Narrow focus of input iptables chain so that it only applies to 
+  Calico-handled traffic.
 - Provide warning log when attempting to use Neutron networks that are not of
   type 'local' or 'flat' with Calico.
 - Handle invalid JSON in IPAM key in etcd.

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -138,6 +138,16 @@ def install_global_rules(config, v4_filter_updater, v6_filter_updater,
             )
 
         forward_chain = [
+            "--append %s --in-interface %s --match conntrack "
+            "--ctstate INVALID --jump DROP" % (CHAIN_FORWARD, iface_match),
+            "--append %s --out-interface %s --match conntrack "
+            "--ctstate INVALID --jump DROP" % (CHAIN_FORWARD, iface_match),
+            "--append %s --in-interface %s --match conntrack "
+            "--ctstate RELATED,ESTABLISHED --jump RETURN" %
+            (CHAIN_FORWARD, iface_match),
+            "--append %s --out-interface %s --match conntrack "
+            "--ctstate RELATED,ESTABLISHED --jump RETURN" %
+            (CHAIN_FORWARD, iface_match),
             "--append %s --jump %s --in-interface %s" %
             (CHAIN_FORWARD, CHAIN_FROM_ENDPOINT, iface_match),
             "--append %s --jump %s --out-interface %s" %

--- a/calico/felix/frules.py
+++ b/calico/felix/frules.py
@@ -371,8 +371,6 @@ def _build_input_chain(iface_match, metadata_addr, metadata_port,
     Returns a list of rules that should be applied to the felix-INPUT chain.
     :returns Tuple: list of rules and set of deps.
     """
-    # Optimisation: return immediately if the traffic is not from one of the
-    # interfaces we're managing.
     chain = []
 
     if hosts_set_name:
@@ -384,6 +382,9 @@ def _build_input_chain(iface_match, metadata_addr, metadata_port,
             "--match set ! --match-set %s src --jump DROP" %
             (CHAIN_INPUT, hosts_set_name)
         )
+
+    # Optimisation: return immediately if the traffic is not from one of the
+    # interfaces we're managing.
     chain.append("--append %s ! --in-interface %s --jump RETURN" %
                  (CHAIN_INPUT, iface_match,))
     deps = set()

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -153,6 +153,26 @@ class TestRules(BaseTestCase):
         ])
         self.assertEqual(deps, set())
 
+    def test_build_input_chain_ipip(self):
+        chain, deps = frules._build_input_chain("tap+",
+                                                "123.0.0.1",
+                                                1234,
+                                                546, 547,
+                                                False,
+                                                "DROP",
+                                                "felix-hosts")
+        self.assertEqual(chain, [
+            '--append felix-INPUT --protocol ipencap --match set ! --match-set felix-hosts src --jump DROP',
+            '--append felix-INPUT ! --in-interface tap+ --jump RETURN',
+            '--append felix-INPUT --match conntrack --ctstate INVALID --jump DROP',
+            '--append felix-INPUT --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+            '--append felix-INPUT --protocol tcp --destination 123.0.0.1 --dport 1234 --jump ACCEPT',
+            '--append felix-INPUT --protocol udp --sport 546 --dport 547 --jump ACCEPT',
+            '--append felix-INPUT --protocol udp --dport 53 --jump ACCEPT',
+            '--append felix-INPUT --jump DROP',
+        ])
+        self.assertEqual(deps, set())
+
     def test_build_input_chain_return(self):
         chain, deps = frules._build_input_chain("tap+",
                                                 None,

--- a/calico/felix/test/test_frules.py
+++ b/calico/felix/test/test_frules.py
@@ -134,3 +134,44 @@ class TestRules(BaseTestCase):
         with self.assertRaises(AssertionError):
             _rule_to_iptables_fragment("foo", {"protocol": "10",
                                                "src_ports": [1]}, 4, {})
+
+    def test_build_input_chain(self):
+        chain, deps = frules._build_input_chain("tap+",
+                                                "123.0.0.1",
+                                                1234,
+                                                546, 547,
+                                                False,
+                                                "DROP")
+        self.assertEqual(chain, [
+            '--append felix-INPUT ! --in-interface tap+ --jump RETURN',
+            '--append felix-INPUT --match conntrack --ctstate INVALID --jump DROP',
+            '--append felix-INPUT --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+            '--append felix-INPUT --protocol tcp --destination 123.0.0.1 --dport 1234 --jump ACCEPT',
+            '--append felix-INPUT --protocol udp --sport 546 --dport 547 --jump ACCEPT',
+            '--append felix-INPUT --protocol udp --dport 53 --jump ACCEPT',
+            '--append felix-INPUT --jump DROP',
+        ])
+        self.assertEqual(deps, set())
+
+    def test_build_input_chain_return(self):
+        chain, deps = frules._build_input_chain("tap+",
+                                                None,
+                                                None,
+                                                546, 547,
+                                                True,
+                                                "RETURN")
+        self.assertEqual(chain, [
+            '--append felix-INPUT ! --in-interface tap+ --jump RETURN',
+            '--append felix-INPUT --match conntrack --ctstate INVALID --jump DROP',
+            '--append felix-INPUT --match conntrack --ctstate RELATED,ESTABLISHED --jump ACCEPT',
+            '--append felix-INPUT --jump ACCEPT --protocol ipv6-icmp --icmpv6-type 130',
+            '--append felix-INPUT --jump ACCEPT --protocol ipv6-icmp --icmpv6-type 131',
+            '--append felix-INPUT --jump ACCEPT --protocol ipv6-icmp --icmpv6-type 132',
+            '--append felix-INPUT --jump ACCEPT --protocol ipv6-icmp --icmpv6-type 134',
+            '--append felix-INPUT --jump ACCEPT --protocol ipv6-icmp --icmpv6-type 135',
+            '--append felix-INPUT --jump ACCEPT --protocol ipv6-icmp --icmpv6-type 136',
+            '--append felix-INPUT --protocol udp --sport 546 --dport 547 --jump ACCEPT',
+            '--append felix-INPUT --protocol udp --dport 53 --jump ACCEPT',
+            '--append felix-INPUT --jump felix-FROM-ENDPOINT',
+        ])
+        self.assertEqual(deps, set(["felix-FROM-ENDPOINT"]))


### PR DESCRIPTION
@Lukasa this is still a work in progress but I wanted to ask if you know why we need a blanket ICMPv6 ACCEPT in the FORWARD chain.  I can see why we'd want it i the INPUT chain, since we need to play nice as a router, but is it needed in the FORWARD chain?

Also, I wanted to make sure that it was correct to match on tap+ for the metadata rule.  That was missing before.