### PR TITLE
Fix log rotation problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Provide warning log when attempting to use Neutron networks that are not of
   type 'local' or 'flat' with Calico.
 - Handle invalid JSON in IPAM key in etcd.
+- Move all log rotation into logrotate and out of Felix, to prevent conflicts.
+- Change log rotation strategy for logrotate to not rotate small log files.
 
 ## 0.25
 

--- a/calico/common.py
+++ b/calico/common.py
@@ -263,7 +263,7 @@ def complete_logging(logfile=None,
                 root_logger.removeHandler(handler)
             else:
                 handler.setLevel(stream_level)
-        elif isinstance(handler, logging.handlers.TimedRotatingFileHandler):
+        elif isinstance(handler, logging.handlers.WatchedFileHandler):
             file_handler = handler
             if file_level is None:
                 root_logger.removeHandler(handler)
@@ -275,9 +275,7 @@ def complete_logging(logfile=None,
         if not file_handler:
             mkdir_p(os.path.dirname(logfile))
             formatter = logging.Formatter(FORMAT_STRING)
-            file_handler = logging.handlers.TimedRotatingFileHandler(
-                logfile, when="D", backupCount=10
-            )
+            file_handler = logging.handlers.WatchedFileHandler(logfile)
             file_handler.addFilter(GreenletFilter())
             file_handler.setLevel(file_level)
             file_handler.setFormatter(formatter)

--- a/debian/calico-felix.logrotate
+++ b/debian/calico-felix.logrotate
@@ -3,5 +3,5 @@
     missingok
     compress
     delaycompress
-    notifempty
+    minsize 1M
 }

--- a/rpm/calico-felix.logrotate
+++ b/rpm/calico-felix.logrotate
@@ -3,5 +3,5 @@
     missingok
     compress
     delaycompress
-    notifempty
+    minsize 1M
 }

--- a/rpm/calico-felix.logrotate
+++ b/rpm/calico-felix.logrotate
@@ -1,0 +1,7 @@
+/var/log/calico/felix.log {
+    daily
+    missingok
+    compress
+    delaycompress
+    notifempty
+}

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -7,6 +7,7 @@ Release:        1%{?dist}
 License:        Apache-2
 URL:            http://projectcalico.org
 Source0:        calico-%{version}.tar.gz
+Source1:        calico-felix.logrotate
 Source35:	calico-felix.conf
 Source45:	calico-felix.service
 BuildArch:	noarch
@@ -168,6 +169,9 @@ install -d %{buildroot}%{_bindir}
 install -m 755 etc/*.sh %{buildroot}%{_bindir}
 install -m 755 utils/diags.sh %{buildroot}%{_bindir}/calico-diags
 
+install -d -m 755 %{buildroot}/%{_sysconfdir}/logrotate.d
+install    -m 644 %_sourcedir/calico-felix.logrotate    %{buildroot}/%{_sysconfdir}/logrotate.d/calico-felix
+
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -199,6 +203,7 @@ rm -rf $RPM_BUILD_ROOT
 %else
     %{_sysconfdir}/init/calico-felix.conf
 %endif
+%{_sysconfdir}/logrotate.d/calico-felix
 %doc
 
 


### PR DESCRIPTION
This resolves #249.

Generally we have an inconsistent attitude to logging. Felix rotates its own logs. Additionally, we install logrotate files for Ubuntu, but not for Red Hat. The upshot of this is that:

- When installed from source, Felix rotates its own logs but does not compress them.
- When installed from RPM, Felix rotates its own logs but does not compress them.
- When installed from .deb, Felix attempts to rotate its logs, so does logrotate, and it all goes to crap. Also, the logs rotated by logrotate *do* get compressed, but the ones rotated by Felix simply don't.

This patch resolves this problem in two ways.

Firstly, it stops Felix rotating its logs. Log rotation is simply not Felix's problem, so it should stop doing it.

Secondly, it adds logrotate handling to the RPM files so that Felix's logs are consistently rotated. logrotate is better at log rotation than Felix (it compresses logs, for example), so we should be using it.

Longer term I'd like to talk about whether Felix should log to file *at all*, but for now this is a good start.

Interested parties: @matthewdupre for review, @plwhite because he cares a lot about logging, @fasaxc because he cares a lot about Felix and also RPM.