### PR TITLE
Remove unused time_ms method

### DIFF
--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -136,13 +136,6 @@ def hex(string):
     """
     return "".join(x.encode('hex') for x in string)
 
-def time_ms():
-    """
-    Return the time in ms. We use this rather than directly calling time.time
-    mostly because it makes it easier to mock out for test purposes.
-    """
-    return(int(time.time() * 1000))
-
 
 def net_to_ip(net_or_ip):
     return net_or_ip.split("/")[0]

--- a/calico/felix/test/test_futils.py
+++ b/calico/felix/test/test_futils.py
@@ -60,10 +60,6 @@ class TestFutils(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_time_ms(self):
-        # Bit feeble, but validate that we can call it and get back something.
-        time_ms = futils.time_ms()
-
     def test_good_check_call(self):
         # Test a command. Result must include "calico" given where it is run from.
         args = ["ls"]


### PR DESCRIPTION
Discovered while doing research on #120. I think we just don't need this.

No changelog update because end users don't care about the removal of dead code.