### PR TITLE
Minor tidy-ups in futils.py

### DIFF
--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -43,7 +43,7 @@ IPV4 = "IPv4"
 IPV6 = "IPv6"
 IP_TYPES = [IPV4, IPV6]
 IP_VERSIONS = [4, 6]
-IP_TYPE_TO_VERSION = { IPV4: 4, IPV6: 6 }
+IP_TYPE_TO_VERSION = {IPV4: 4, IPV6: 6}
 
 SHORTENED_PREFIX = "_"
 
@@ -134,7 +134,7 @@ def hex(string):
     """
     Convert a string to hex.
     """
-    return "".join(x.encode('hex') for x in string)
+    return string.encode('hex')
 
 
 def net_to_ip(net_or_ip):
@@ -244,7 +244,7 @@ def intern_list(l):
     """
     Returns a new list with interned versions of the input list's contents.
 
-    Non-strings are copied to the new list verbatim.  returned strings are e
+    Non-strings are copied to the new list verbatim.  Returned strings are
     encoded using .encode("utf8").
     """
     out = []

--- a/calico/felix/futils.py
+++ b/calico/felix/futils.py
@@ -175,7 +175,7 @@ class StatCounter(object):
         register_diags(name, self._dump)
 
     def increment(self, stat, by=1):
-        self.stats[stat] += 1
+        self.stats[stat] += by
 
     def _dump(self, log):
         stats_copy = self.stats.items()

--- a/calico/felix/test/test_futils.py
+++ b/calico/felix/test/test_futils.py
@@ -140,11 +140,13 @@ class TestStats(unittest.TestCase):
         self.assertEqual(self.sc.stats["bar"], 1)
         self.sc.increment("bar")
         self.assertEqual(self.sc.stats["bar"], 2)
+        self.sc.increment("baz", by=2)
+        self.assertEqual(self.sc.stats["baz"], 3)
         m_log = mock.Mock(spec=logging.Logger)
         self.sc._dump(m_log)
         m_log.assert_has_calls([
             mock.call.info("%s: %s", "bar", 2),
-            mock.call.info("%s: %s", "baz", 1),
+            mock.call.info("%s: %s", "baz", 3),
         ])
 
     def test_dump_diags(self):


### PR DESCRIPTION
Spotted while I was reading the code: the `by` argument is unused. I made a guess at how it was meant to be used.

@fasaxc Assigning to you because you wrote this code originally, and are most likely to know whether this change is correct.