### PR TITLE
Stop restarting Felix on Ubuntu if it fails more than 5 times in 10 seconds (consistent with Red Hat behavior)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.27-dev
+
+- Stop restarting Felix on Ubuntu if it fails more than 5 times in 10 seconds.
+
 ## 0.26
 
 - Update and improve security model documentation.

--- a/debian/calico-felix.upstart
+++ b/debian/calico-felix.upstart
@@ -8,6 +8,7 @@ stop on runlevel [!2345]
 limit nofile 32000 32000
 
 respawn
+respawn limit 5 10
 
 chdir /var/run
 


### PR DESCRIPTION
Fixes issue #705.