### PR TITLE
Remove DHCP checksum fix from Calico compute node install process (Neutron does it instead)

### DIFF
--- a/debian/calico-compute.postinst
+++ b/debian/calico-compute.postinst
@@ -4,16 +4,6 @@ set -e
 
 if [ "$1" = "configure" ]
 then
-    # Enable checksum calculation on DHCP responses.  This is needed
-    # when sending DHCP responses over the TAP interfaces to guest
-    # VMs, as apparently Linux doesn't itself do the checksum
-    # calculation in that case.
-    iptables -C POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill ||
-    iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill
-
-    # Save current iptables for subsequent reboots.
-    iptables-save > /etc/iptables/rules.v4
-
     # Enable IP forwarding.
     echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
     echo "net.ipv6.conf.all.forwarding=1" >> /etc/sysctl.conf

--- a/rpm/calico.spec
+++ b/rpm/calico.spec
@@ -40,13 +40,6 @@ This package provides the pieces needed on a compute node.
 if [ $1 -eq 1 ] ; then
     # Initial installation
 
-    # Enable checksum calculation on DHCP responses.  This is needed
-    # when sending DHCP responses over the TAP interfaces to guest
-    # VMs, as apparently Linux doesn't itself do the checksum
-    # calculation in that case.
-    iptables -D POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill >/dev/null 2>&1 || true
-    iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill
-
     # Don't reject INPUT and FORWARD packets by default on the compute host.
     iptables -D INPUT -j REJECT --reject-with icmp-host-prohibited >/dev/null 2>&1 || true
     iptables -D FORWARD -j REJECT --reject-with icmp-host-prohibited >/dev/null 2>&1 || true


### PR DESCRIPTION
First part of the fix to #40.  Must not be merged until the Neutron change is backported to Icehouse and Juno.