### PR TITLE
Refactor the resync code.

### DIFF
--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -721,11 +721,11 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             try:
                 etcd_data = json.loads(endpoint.data)
             except (ValueError, TypeError):
-                # If the JSON data is bad, just ignore it. We can't blow up
-                # here because that will trigger a new resync on another node
-                # that will blow *it* up as well. Just tolerate it.
+                # If the JSON data is bad, we need to fix it up. Set a value
+                # that is impossible for Neutron to be returning: nothing at
+                # all.
                 LOG.exception("Bad JSON data in key %s", endpoint.key)
-                continue
+                etcd_data = []
 
             port = self.add_extra_port_information(context, port)
             neutron_data = port_etcd_data(port)

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -655,8 +655,8 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
 
         # Finally, scan each of the ports in changes_ports. Work out if there
         # are any differences. If there are, write out to etcd.
-        changed_endpoints = (e for e in endpoints if e.id in changes_ports)
-        self._resync_changed_ports(context, changed_endpoints)
+        common_endpoints = (e for e in endpoints if e.id in changes_ports)
+        self._resync_changed_ports(context, common_endpoints)
 
     def _resync_missing_ports(self, context, missing_port_ids):
         """
@@ -696,17 +696,17 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 LOG.info('Endpoint %s was deleted elsewhere', endpoint)
                 continue
 
-    def _resync_changed_ports(self, context, changed_endpoints):
+    def _resync_changed_ports(self, context, common_endpoints):
         """
         Reconcile all changed profiles by checking whether Neutron and etcd
         agree.
 
         :param context: A Neutron DB context.
-        :param changed_endpoints: An iterable of Endpoint objects that should
+        :param common_endpoints: An iterable of Endpoint objects that should
             be checked for changes.
         :returns: Nothing.
         """
-        for endpoint in changed_endpoints:
+        for endpoint in common_endpoints:
             # Get the endpoint data from etcd.
             try:
                 endpoint = self.transport.get_endpoint_data(endpoint)

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -722,11 +722,14 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 LOG.exception("Bad JSON data in key %s", endpoint.key)
                 continue
 
-            self.add_port_gateways(port, context)
-            self.add_port_interface_name(port)
+            port['fixed_ips'] = self.get_fixed_ips_for_port(
+                context, port
+            )
             port['security_groups'] = self.get_security_groups_for_port(
                 context, port
             )
+            self.add_port_gateways(port, context)
+            self.add_port_interface_name(port)
             neutron_data = port_etcd_data(port)
 
             if etcd_data != neutron_data:

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -715,7 +715,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             # Get the data for both.
             try:
                 etcd_data = json.loads(endpoint.data)
-            except Exception:
+            except (ValueError, TypeError):
                 # If the JSON data is bad, just ignore it. We can't blow up
                 # here because that will trigger a new resync on another node
                 # that will blow *it* up as well. Just tolerate it.
@@ -802,8 +802,10 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
         # Finally, reconcile the security profiles. This involves looping over
         # them, grabbing their data, and then comparing that to what Neutron
         # has.
-        changed_profiles = (p for p in profiles if p.id in reconcile_groups)
-        for etcd_profile in changed_profiles:
+        profiles_to_reconcile = (
+            p for p in profiles if p.id in reconcile_groups
+        )
+        for etcd_profile in profiles_to_reconcile:
             # Get the data from etcd.
             try:
                 etcd_profile = self.transport.get_profile_data(etcd_profile)
@@ -824,7 +826,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
             try:
                 etcd_rules = json.loads(etcd_profile.rules_data)
                 etcd_tags = json.loads(etcd_profile.tags_data)
-            except Exception:
+            except (ValueError, TypeError):
                 # If the JSON data is bad, just ignore it. We can't blow up
                 # here because that will trigger a new resync on another node
                 # that will blow *it* up as well. Just tolerate it.

--- a/calico/openstack/mech_calico.py
+++ b/calico/openstack/mech_calico.py
@@ -710,7 +710,7 @@ class CalicoMechanismDriver(mech_agent.SimpleAgentMechanismDriverBase):
                 continue
 
             with context.session.begin(subtransactions=True):
-                port = self.db.get_port(endpoint.id)
+                port = self.db.get_port(context, endpoint.id)
 
             # Get the data for both.
             try:

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -398,7 +398,13 @@ class CalicoTransportEtcd(object):
                 rules_modified = rules_indices.pop(profile_id)
 
                 LOG.debug("Found profile id %s", profile_id)
-                yield Profile(profile_id, tag_modified, rules_modified)
+                yield Profile(
+                    profile_id,
+                    tag_modified,
+                    rules_modified,
+                    None,
+                    None,
+                )
 
         # Quickly confirm that the tag and rule indices are empty (they should
         # be).

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -69,6 +69,11 @@ LOG = log.getLogger(__name__)
 
 # Objects for lightly wrapping etcd return values for use in the mechanism
 # driver.
+# These namedtuples are getting pretty heavyweight at this point. If you find
+# yourself wanting to add more fields to them, consider rewriting them as full
+# classes. Note that several of the properties of namedtuples are desirable for
+# these objects (immutability being the biggest), so if you rewrite as classes
+# attempt to preserve those properties.
 Endpoint = namedtuple(
     'Endpoint', ['id', 'key', 'modified_index', 'host', 'data']
 )
@@ -264,11 +269,11 @@ class CalicoTransportEtcd(object):
         result = self.client.read(endpoint.key, timeout=5)
 
         return Endpoint(
-            endpoint.id,
-            endpoint.key,
-            result.modifiedIndex,
-            endpoint.host,
-            result.value,
+            id=endpoint.id,
+            key=endpoint.key,
+            modified_index=result.modifiedIndex,
+            host=endpoint.host,
+            data=result.value,
         )
 
     @_handling_etcd_exceptions
@@ -298,7 +303,11 @@ class CalicoTransportEtcd(object):
 
             LOG.debug("Found endpoint %s", endpoint_id)
             yield Endpoint(
-                endpoint_id, node.key, node.modifiedIndex, host, None
+                id=endpoint_id,
+                key=node.key,
+                modified_index=node.modifiedIndex,
+                host=host,
+                data=None,
             )
 
     @_handling_etcd_exceptions
@@ -350,11 +359,11 @@ class CalicoTransportEtcd(object):
         )
 
         return Profile(
-            profile.id,
-            tags_result.modifiedIndex,
-            rules_result.modifiedIndex,
-            tags_result.value,
-            rules_result.value,
+            id=profile.id,
+            tags_modified_index=tags_result.modifiedIndex,
+            rules_modified_index=rules_result.modifiedIndex,
+            tags_data=tags_result.value,
+            rules_data=rules_result.value,
         )
 
     @_handling_etcd_exceptions
@@ -399,11 +408,11 @@ class CalicoTransportEtcd(object):
 
                 LOG.debug("Found profile id %s", profile_id)
                 yield Profile(
-                    profile_id,
-                    tag_modified,
-                    rules_modified,
-                    None,
-                    None,
+                    id=profile_id,
+                    tags_modified_index=tag_modified,
+                    rules_modified_index=rules_modified,
+                    tags_data=None,
+                    rules_data=None,
                 )
 
         # Quickly confirm that the tag and rule indices are empty (they should

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -217,7 +217,7 @@ class CalicoTransportEtcd(object):
         LOG.info("Write port %s to etcd", port)
         data = port_etcd_data(port)
         self.client.write(
-            port_etcd_key(port), json.dumps(data), prevIndex=prevIndex
+            port_etcd_key(port), json.dumps(data), prevIndex=prev_index,
         )
 
     @_handling_etcd_exceptions

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -165,18 +165,23 @@ class CalicoTransportEtcd(object):
         return self.elector.master()
 
     @_handling_etcd_exceptions
-    def write_profile_to_etcd(self, profile):
+    def write_profile_to_etcd(self,
+                              profile,
+                              prev_rules_index=None,
+                              prev_tags_index=None):
         """
         Write a single security profile into etcd.
         """
         LOG.debug("Writing profile %s", profile)
         self.client.write(
             key_for_profile_rules(profile.id),
-            json.dumps(profile_rules(profile))
+            json.dumps(profile_rules(profile)),
+            prevIndex=prev_rules_index,
         )
         self.client.write(
             key_for_profile_tags(profile.id),
-            json.dumps(profile_tags(profile))
+            json.dumps(profile_tags(profile)),
+            prevIndex=prev_tags_index,
         )
 
     @_handling_etcd_exceptions
@@ -205,13 +210,15 @@ class CalicoTransportEtcd(object):
         self._cleanup_workload_tree(key)
 
     @_handling_etcd_exceptions
-    def write_port_to_etcd(self, port):
+    def write_port_to_etcd(self, port, prev_index=None):
         """
         Writes a given port dictionary to etcd.
         """
         LOG.info("Write port %s to etcd", port)
         data = port_etcd_data(port)
-        self.client.write(port_etcd_key(port), json.dumps(data))
+        self.client.write(
+            port_etcd_key(port), json.dumps(data), prevIndex=prevIndex
+        )
 
     @_handling_etcd_exceptions
     def provide_felix_config(self):

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -565,8 +565,29 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
             '/calico/v1/host/felix-host-1/workload/openstack/instance-2/endpoint/FACEBEEF-1234-5678'
         ]))
 
-        # Change a small amount of information about the port. Expect a resync
-        # to fix it up.
+        # Change a small amount of information about the port and the security
+        # group. Expect a resync to fix it up.
+        self.db.get_security_groups.return_value[-1] = {
+            'id': 'SG-1',
+            'security_group_rules': [
+                {'remote_group_id': 'SGID-default',
+                 'remote_ip_prefix': None,
+                 'protocol': -1,
+                 'direction': 'ingress',
+                 'ethertype': 'IPv4',
+                 'port_range_min': 5070,
+                 'port_range_max': 5071}]
+        }
+        self.db.get_security_group_rules.return_value[-1] = {
+            'remote_group_id': 'SGID-default',
+            'remote_ip_prefix': None,
+            'protocol': -1,
+            'direction': 'ingress',
+            'ethertype': 'IPv4',
+            'security_group_id': 'SG-1',
+            'port_range_min': 5070,
+            'port_range_max': 5070
+        }
         old_ips = self.osdb_ports[0]['fixed_ips']
         self.osdb_ports[0]['fixed_ips'] = [
             {'subnet_id': '10.65.0/24',
@@ -583,12 +604,41 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
                  "state": "active",
                  "ipv4_gateway": "10.65.0.1",
                  "ipv4_nets": ["10.65.0.188/32"]},
+            '/calico/v1/policy/profile/SG-1/rules':
+                {"outbound_rules": [],
+                 "inbound_rules": [{"dst_ports": [5070],
+                                    "src_tag": "SGID-default",
+                                    "ip_version": 4}]},
+            '/calico/v1/policy/profile/SG-1/tags':
+                ["SG-1"]
         }
         self.assertEtcdWrites(expected_writes)
         self.assertEtcdDeletes(set())
 
         # Reset the state for safety.
         self.osdb_ports[0]['fixed_ips'] = old_ips
+
+        self.db.get_security_groups.return_value[-1] = {
+            'id': 'SG-1',
+            'security_group_rules': [
+                {'remote_group_id': 'SGID-default',
+                 'remote_ip_prefix': None,
+                 'protocol': -1,
+                 'direction': 'ingress',
+                 'ethertype': 'IPv4',
+                 'port_range_min': 5060,
+                 'port_range_max': 5061}]
+        }
+        self.db.get_security_group_rules.return_value[-1] = {
+            'remote_group_id': 'SGID-default',
+            'remote_ip_prefix': None,
+            'protocol': -1,
+            'direction': 'ingress',
+            'ethertype': 'IPv4',
+            'security_group_id': 'SG-1',
+            'port_range_min': 5060,
+            'port_range_max': 5060
+        }
 
     def test_noop_entry_points(self):
         """Call the mechanism driver entry points that are currently


### PR DESCRIPTION
This change follows #711, and includes a straight refactor of the resync code. The goal here is to improve readability by preventing the person reading the code from having to look at a 100+ line function and wonder what stuff is and isn't in scope.

This should not be merged until #711 is, and should in all respects be considered a separate change that is dependent on #711, not a superset of it.