### PR TITLE
Python-etcd does not like keyword arguments

### DIFF
--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -181,15 +181,26 @@ class CalicoTransportEtcd(object):
         Write a single security profile into etcd.
         """
         LOG.debug("Writing profile %s", profile)
+
+        # python-etcd is stupid about the prevIndex keyword argument, so we
+        # need to explicitly filter out None-y values ourselves.
+        rules_kwargs = {}
+        if prev_rules_index is not None:
+            rules_kwargs['prevIndex'] = prev_rules_index
+
+        tags_kwargs = {}
+        if prev_tags_index is not None:
+            tags_kwargs['prevIndex'] = prev_tags_index
+
         self.client.write(
             key_for_profile_rules(profile.id),
             json.dumps(profile_rules(profile)),
-            prevIndex=prev_rules_index,
+            **rules_kwargs,
         )
         self.client.write(
             key_for_profile_tags(profile.id),
             json.dumps(profile_tags(profile)),
-            prevIndex=prev_tags_index,
+            **tags_kwargs,
         )
 
     @_handling_etcd_exceptions
@@ -224,8 +235,14 @@ class CalicoTransportEtcd(object):
         """
         LOG.info("Write port %s to etcd", port)
         data = port_etcd_data(port)
+
+        # python-etcd doesn't keyword argument properly.
+        kwargs = {}
+        if prev_index is not None:
+            kwargs['prevIndex'] = prev_index
+
         self.client.write(
-            port_etcd_key(port), json.dumps(data), prevIndex=prev_index,
+            port_etcd_key(port), json.dumps(data), **kwargs,
         )
 
     @_handling_etcd_exceptions

--- a/calico/openstack/t_etcd.py
+++ b/calico/openstack/t_etcd.py
@@ -195,12 +195,13 @@ class CalicoTransportEtcd(object):
         self.client.write(
             key_for_profile_rules(profile.id),
             json.dumps(profile_rules(profile)),
-            **rules_kwargs,
+            **rules_kwargs
         )
+
         self.client.write(
             key_for_profile_tags(profile.id),
             json.dumps(profile_tags(profile)),
-            **tags_kwargs,
+            **tags_kwargs
         )
 
     @_handling_etcd_exceptions
@@ -242,7 +243,7 @@ class CalicoTransportEtcd(object):
             kwargs['prevIndex'] = prev_index
 
         self.client.write(
-            port_etcd_key(port), json.dumps(data), **kwargs,
+            port_etcd_key(port), json.dumps(data), **kwargs
         )
 
     @_handling_etcd_exceptions

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -59,7 +59,7 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         self.maybe_reset_etcd()
 
         # Confirm that, if prevIndex is provided, its value is not None.
-        self.assertIsNotNone(kwargs.get('prevIndex', 0))
+        self.assertTrue(kwargs.get('prevIndex', 0) is not None)
 
         print "etcd write: %s\n%s" % (key, value)
         self.etcd_data[key] = value

--- a/calico/openstack/test/test_plugin_etcd.py
+++ b/calico/openstack/test/test_plugin_etcd.py
@@ -57,6 +57,10 @@ class TestPluginEtcd(lib.Lib, unittest.TestCase):
         database.
         """
         self.maybe_reset_etcd()
+
+        # Confirm that, if prevIndex is provided, its value is not None.
+        self.assertIsNotNone(kwargs.get('prevIndex', 0))
+
         print "etcd write: %s\n%s" % (key, value)
         self.etcd_data[key] = value
         try:


### PR DESCRIPTION
This fixes a current FV failure.