### PR TITLE
Gevent broke their newly-added PyPy support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ deps =
     coverage==4.0a5
     unittest2
     git+https://github.com/Metaswitch/python-etcd.git@3f14a002c9a75df3242de3d81a91a2e6bd32c5a8#egg=python-etcd
-    gevent>=1.1a2
+    gevent>=1.1a2, !=1.1b1


### PR DESCRIPTION
So let's ignore that version.